### PR TITLE
add missing space and parameter value in prohibited msgs in #368

### DIFF
--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -6,7 +6,7 @@
   <% else %>
     <% if @content.errors.any? %>
       <div id="errorExplanation">
-        <h2><%= pluralize(@content.errors.count, t(:error)) + t(:prohibited_save, :model => 'content') %></h2>
+        <h2><%= pluralize(@content.errors.count, t(:error)) + ' ' + t(:prohibited_save, :model => 'content') %></h2>
         <ul>
           <% @content.errors.full_messages.each do |msg| %>
             <li><%= msg %></li>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -2,7 +2,7 @@
 	<%= form_for(@group) do |f| %>
 		<% if @group.errors.any? %>
 		<div id="errorExplanation">
-		<h2><%= pluralize(@group.errors.count, "error") + " " + t(:prohibited_save) %></h2>
+		<h2><%= pluralize(@group.errors.count, "error") + " " + t(:prohibited_save, :model => 'group') %></h2>
 		<ul>
 		  <% @group.errors.full_messages.each do |msg| %>
 		    <li><%= msg %></li>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -10,7 +10,7 @@
         	<%= form_for(@group) do |f| %>
         		<% if @group.errors.any? %>
         		<div id="errorExplanation">
-        		<h2><%= pluralize(@group.errors.count, "error") + " " + t(:prohibited_save) %></h2>
+        		<h2><%= pluralize(@group.errors.count, "error") + " " + t(:prohibited_save, :model => 'user group') %></h2>
         		<ul>
         		  <% @group.errors.full_messages.each do |msg| %>
         		    <li><%= msg %></li>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -8,7 +8,7 @@
        <%= form_for(@group) do |f| %>
        <% if @group.errors.any? %>
        <div id="errorExplanation">
-          <h2><%= pluralize(@group.errors.count, "error") + " " + t(:prohibited_save) %></h2>
+          <h2><%= pluralize(@group.errors.count, "error") + " " + t(:prohibited_save, :model =>'user group') %></h2>
           <ul>
             <% @group.errors.full_messages.each do |msg| %>
             <li><%= msg %></li>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@user) do |f| %>
 <% if @user.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(@user.errors.count, t(:error)) + t(:prohibited_save, :model => 'user') %></h2>
+      <h2><%= pluralize(@user.errors.count, t(:error)) + ' ' + t(:prohibited_save, :model => 'user') %></h2>
 
       <ul>
 	<% @user.errors.full_messages.each do |msg| %>


### PR DESCRIPTION
Added missing space for some instances where the prohibited_save message was running into the following text and passing the "model name" where it was expecting a variable for interpolation.

(There are still outstanding items in issue #368 so don't close it yet.)
