### PR TITLE
place awesome quotes around ticker text in the tile

### DIFF
--- a/app/views/contents/_render_tile.html.erb
+++ b/app/views/contents/_render_tile.html.erb
@@ -1,3 +1,3 @@
 <div class="default-padding">
-  <i class="ficon-large ficon-quote-left muted"></i> <%= content.data %> <i class="ficon-large ficon-quote-right muted"></i> 
+  <%= content.data %>
 </div>

--- a/app/views/contents/ticker/_render_default.html.erb
+++ b/app/views/contents/ticker/_render_default.html.erb
@@ -1,5 +1,3 @@
 <div class="content-ticker">
-  <p class="quotemarks-top">"</p>
-  <p><%= content.data %></p>
-  <p class="quotemarks-bottom">"</p>
+  <p><i class="ficon-quote-left icon-large muted"></i> <%= content.data %> <i class="ficon-quote-right icon-large muted"></i> </p>
 </div>

--- a/app/views/contents/ticker/_render_tile.html.erb
+++ b/app/views/contents/ticker/_render_tile.html.erb
@@ -1,0 +1,3 @@
+<div class="default-padding">
+  <i class="icon-large ficon-quote-left muted"></i> <%= content.data %> <i class="icon-large ficon-quote-right muted"></i>
+</div>


### PR DESCRIPTION
@brzaik here's the PR that depends on the fontawesome update #422.  It adds quotes around the ticker text shown in the tile, and changes from plain text quotes on the show view to font-awesome quotes.  If the other PR makes it through, can you merge this one too?  Thanks.
