### PR TITLE
Shortened the Active Approved Content Label and made changes for #394

### DIFF
--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -44,7 +44,7 @@
           </div>
           <br /><br />
           <div class="clearfix">
-            <h3><%= t(:current_active_approved_content) + ": " + @active_content.to_s %></h3>
+            <h3><%= t('.active_content') %>: <%= @active_content.to_s %></h3>
           </div>
         </div>
         


### PR DESCRIPTION
Sorry for the delay, made the minor changes to the current active approved content counter by shortening the label to active content and pulling the ": " strings out of the feeds index view. 
