### PR TITLE
show name of user when changing password

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <section class="viewblock no">
   <header class="viewblock-header">
-		<h1 class="default-padding"><%= t('.change_password') %></h1>
+		<h1 class="default-padding"><%= t('.change_password_for', :username  => resource.name) %></h1>
   </header>
   <div class="viewblock-cont">
 		<%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f| %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -39,6 +39,7 @@ en:
       destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
       edit:
         change_password: 'Change Password'
+        change_password_for: 'Change Password for %{username}'
         current_password: 'Current password'
         new_password: 'New password'
         confirm_password: 'Confirm new password'


### PR DESCRIPTION
This is really important because you need to know who you are changing the password of, and with the current code, the manage users > show > change password is actually affecting the current user not the selected user.
