### PR TITLE
include field_configs as config array in setup.json for frontend

### DIFF
--- a/app/controllers/frontend/screens_controller.rb
+++ b/app/controllers/frontend/screens_controller.rb
@@ -64,6 +64,7 @@ class Frontend::ScreensController < ApplicationController
       @screen.template.path = frontend_screen_template_path(@screen, @screen.template, :format => template_format)      
       @screen.template.positions.each do |p|
         p.field_contents_path = frontend_screen_field_contents_path(@screen, p.field, :format => :json)
+        p.field.field_configs = FieldConfig.where(:screen_id => @screen.id, :field_id => p.field.id)
       end
 
       respond_to do |format|
@@ -78,7 +79,12 @@ class Frontend::ScreensController < ApplicationController
                     :methods => [:field_contents_path],
                     :include => {
                       :field => {
-                        :only => [:id, :name]
+                        :only => [:id, :name],
+                        :include => {
+                          :config => {
+                            :only => [:key, :value, :value_type]
+                          }
+                        }
                       }
                     }
                   },

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -7,6 +7,8 @@ class Field < ActiveRecord::Base
   has_many :field_configs, :dependent => :destroy
   #has_many :screens, :through => :field_configs   # valid, but not used yet
   
+  alias_method :config, :field_configs  # for setup.json formatting
+
   # Validations
   validates :name, :presence => true
 end


### PR DESCRIPTION
'nuff said.  here's a sample 

```
{
  "id": 1,
  "name": "Sample Screen",
  "template": {
    "id": 2,
    "path": "\/frontend\/1\/templates\/2",
    "positions": [
      {
        "bottom": "0.8",
        "id": 5,
        "left": "0.1",
        "right": "0.9",
        "style": "",
        "top": "0.1",
        "field_contents_path": "\/frontend\/1\/fields\/1\/contents.json",
        "field": {
          "id": 1,
          "name": "Graphics",
          "config": [
            {
              "key": "transition",
              "value": "fade",
              "value_type": "string"
            },
            {
              "key": "order",
              "value": "random",
              "value_type": "string"
            }
          ]
        }
      },
      {
        "bottom": "0.98",
        "id": 7,
        "left": "0.5",
        "right": "0.9",
        "style": "",
        "top": "0.8",
        "field_contents_path": "\/frontend\/1\/fields\/2\/contents.json",
        "field": {
          "id": 2,
          "name": "Ticker",
          "config": [
            {
              "key": "scrolling_marquis",
              "value": "true",
              "value_type": "string"
            }
          ]
        }
      }
    ]
  }
}
```
