### PR TITLE
change quoting to use backticks

### DIFF
--- a/app/controllers/concerto_config_controller.rb
+++ b/app/controllers/concerto_config_controller.rb
@@ -3,7 +3,7 @@ class ConcertoConfigController < ApplicationController
   # GET /settings
   def show
     authorize! :read, ConcertoConfig
-    @concerto_configs = ConcertoConfig.where("hidden IS NULL").order('"group", seq_no, "key"')
+    @concerto_configs = ConcertoConfig.where("hidden IS NULL").order("`group`, seq_no, `key`")
   end
 
   # get a hash of concerto_config keys and values and update them using the ConcertoConfig setter


### PR DESCRIPTION
sqlite respects the single quoting, but mysql treats it as a literal, so had to change to backticks which works for both.
