### PR TITLE
Update JS so frontend renders in IE9

### DIFF
--- a/app/views/frontend/screens/show.html.erb
+++ b/app/views/frontend/screens/show.html.erb
@@ -4,7 +4,7 @@
     <script src="<%= frontend_js_path js_file %>" type="text/javascript"></script>
   <% end %>
   <script type="text/javascript">
-    var screen;
+    var thescreen;
     function init() {
       <% if @debug %>
         var debugWindow = new goog.debug.FancyWindow('main');
@@ -16,7 +16,7 @@
         setupPath: '<%=j setup_frontend_screen_path(@screen, :format => :json) %>',
         <% if @preview %> isPreview: true, <% end %>
       };
-      screen = new concerto.frontend.Screen(<%= @screen.id %>, div, screenOptions);
+      thescreen = new concerto.frontend.Screen(<%= @screen.id %>, div, screenOptions);
     }
     window.addEventListener('load', init, false);
   </script>


### PR DESCRIPTION
Fixes Issue #379
"screen" collides with an existing reserved word in IE9.  This causes an error "SCRIPT5039: Redeclaration of const property" on line 19, preventing the JS code from compiling and running.

Changed to non-reserved word "thescreen".  Tested OK on IE9 (NOT compatibility mode!), Chrome, Firefox.
