### PR TITLE
add ordering to the individual queries

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -40,17 +40,17 @@ private
     activities = []
     if current_user && defined? PublicActivity::Activity
       #Retrieve the activities for which the current user is an owner or recipient (making sure the STI field specifies user as the Type)
-      owner = PublicActivity::Activity.where(:owner_id => current_user.id, :owner_type => 'User').limit(activity_limit)
-      recipient = PublicActivity::Activity.where(:recipient_id => current_user.id, :recipient_type => 'User').limit(activity_limit)
+      owner = PublicActivity::Activity.where(:owner_id => current_user.id, :owner_type => 'User').order('updated_at desc').limit(activity_limit)
+      recipient = PublicActivity::Activity.where(:recipient_id => current_user.id, :recipient_type => 'User').order('updated_at desc').limit(activity_limit)
 
       #Select the activities that involve a group as the recipient for which the user is a member
-      group_member = PublicActivity::Activity.where(:recipient_id => current_user.group_ids, :recipient_type => "Group").limit(activity_limit)
+      group_member = PublicActivity::Activity.where(:recipient_id => current_user.group_ids, :recipient_type => "Group").order('updated_at desc').limit(activity_limit)
 
       #Select activities with neither an owner nor a recipient (public activities) - the actual owner is set in the parameters hash for these...let's ditch this arel hack in Rails 4 please
-      public_activities = PublicActivity::Activity.where(:owner_id => nil, :recipient_id => nil).where(PublicActivity::Activity.arel_table[:trackable_type].not_eq("ConcertoConfig")).limit(activity_limit)
+      public_activities = PublicActivity::Activity.where(:owner_id => nil, :recipient_id => nil).where(PublicActivity::Activity.arel_table[:trackable_type].not_eq("ConcertoConfig")).order('updated_at desc').limit(activity_limit)
       
       if current_user.is_admin?
-        system_notifications = PublicActivity::Activity.where(:trackable_type => "ConcertoConfig").limit(activity_limit)
+        system_notifications = PublicActivity::Activity.where(:trackable_type => "ConcertoConfig").order('updated_at desc').limit(activity_limit)
         activities = owner + recipient + group_member + public_activities + system_notifications
       else
         activities = owner + recipient + group_member + public_activities


### PR DESCRIPTION
The "Latest Activity" on the dashboard was not pulling the latest activity.  Please note that the ActiveRecord Querying Guide http://guides.rubyonrails.org/active_record_querying.html#ordering says that you should be able to use `order(:updated_at => :desc)` but this did not work, so we used the text equivalent instead.
