### PR TITLE
Error if no controller hooks are specified in plugin

### DIFF
--- a/lib/concerto/plugin_info.rb
+++ b/lib/concerto/plugin_info.rb
@@ -99,8 +99,10 @@ module Concerto
     # Returns an array of hashes specifying all of the requested
     # hooks into the given controller.
     def get_controller_hooks(controller_name)
-      return @controller_hooks.select do |h| 
-        h[:controller_name] == controller_name
+      if @controller_hooks
+        return @controller_hooks.select do |h| 
+          h[:controller_name] == controller_name
+        end
       end
     end
 


### PR DESCRIPTION
When testing a plugin with no controller hooks, I noticed select being called on @controller_hooks which is nil, causing a no method error page. 
