### PR TITLE
Fix feed visibility

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -11,7 +11,7 @@ class DashboardController < ApplicationController
     if current_user
       # Browse + Vitals share feeds.
       @feeds = Feed.roots
-      auth!(!:object => @feeds)
+      auth!(:object => @feeds)
 
       # Latest Activities
       @activities = get_activities(10)


### PR DESCRIPTION
wrong auth call caused the read permission to be not checked, thus feeds were not correctly filtered. (`!:object` evaluates to `false`)
