### PR TITLE
Adding progress indicator to pages loaded via Turbolinks.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,6 @@ gem 'public_activity'
 
 gem 'redcarpet'
 gem 'docsplit', :git => 'https://github.com/augustf/docsplit.git', :branch => 'imagemagick'
+
+# NProgress provides progress bars for pages loaded via Turbolinks
+gem 'nprogress-rails', '~> 0.1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,8 +136,8 @@ GEM
     multi_json (1.10.1)
     multipart-post (2.0.0)
     mysql2 (0.3.16)
+    nprogress-rails (0.1.3.0)
     orm_adapter (0.5.0)
-    pg (0.17.1)
     polyglot (0.3.4)
     public_activity (1.4.1)
       actionpack (>= 3.0.0)
@@ -250,6 +250,7 @@ DEPENDENCIES
   json
   kaminari
   mysql2
+  nprogress-rails (~> 0.1.3.0)
   pg
   public_activity
   rails (~> 3.2.17)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,3 +22,5 @@
 //= require jquery.datepair.js
 //= require jquery.iframe-transport
 //= require_tree .
+#= require nprogress
+#= require nprogress-turbolinks

--- a/app/assets/stylesheets/application/index-manifest.scss
+++ b/app/assets/stylesheets/application/index-manifest.scss
@@ -32,3 +32,5 @@
 @import "responsive/responsive-767px-max";
 @import "responsive/responsive-768px-979px";
 @import "responsive/responsive-1200px-min";
+
+@import "nprogress";


### PR DESCRIPTION
Turbolinks alone does not provide any visual indication that a page is loading.
We want to improve the user experience for those waiting for pages to load.  This fixes that.

**Developer Notes:** Added Gem dependency on nprogress-rails.
