### PR TITLE
fix crash in weighted shuffler when content with id does not exist

### DIFF
--- a/lib/base_shuffle.rb
+++ b/lib/base_shuffle.rb
@@ -2,7 +2,7 @@
 # A simple approach that just grabs all the content
 # without shuffling it or weighing it.
 class BaseShuffle
-  # Initialze all the variables, setup a store if needed.
+  # Initialize all the variables, setup a store if needed.
   #
   # @param [Screen] screen Screen showing the content.
   # @param [Field] field Field showing the content.
@@ -29,8 +29,9 @@ class BaseShuffle
       @store += content.collect{|c| c.id}
     end
     return [] if @store.empty?
+
     content_ids = @store.shift(count)
-    return Content.where(:id => content_ids)
+    Content.where(:id => content_ids).compact
   end
 
   # Return a timeline to be saved.

--- a/lib/weighted_shuffle.rb
+++ b/lib/weighted_shuffle.rb
@@ -12,7 +12,9 @@ class WeightedShuffle < BaseShuffle
       @store += content.collect{|c| c.id}
     end
     return [] if @store.empty?
-    return @store.pop(count).collect{|id| Content.find(id)}
+
+    content_ids = @store.shift(count)
+    Content.where(:id => content_ids).compact
   end
 
   private


### PR DESCRIPTION
When deleting content, the different shufflers (or rather the shuffler store) can still hold old ids to content that does not exist anymore. 
