### PR TITLE
require docsplit

### DIFF
--- a/lib/concerto/content_converter.rb
+++ b/lib/concerto/content_converter.rb
@@ -55,6 +55,8 @@ module Concerto
 
     # Class for converting various document types using the docsplit gem.
     class DocSplitConverter
+      require 'docsplit'
+
       # Converts the first page of the original media to a png and loads it back into 
       #   the media as a processed entry.
       # @param media [Media] the media to convert


### PR DESCRIPTION
This resolved the 

```
NameError - uninitialized constant Concerto::ContentConverter::DocSplitConverter::Docsplit:
```

I was getting on a fresh dev install.
