### PR TITLE
Add free-form metadata column to Content model.

### DIFF
--- a/db/migrate/20140612022826_add_metadata_to_contents.rb
+++ b/db/migrate/20140612022826_add_metadata_to_contents.rb
@@ -1,0 +1,5 @@
+class AddMetadataToContents < ActiveRecord::Migration
+  def change
+    add_column :contents, :metadata, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140523152217) do
+ActiveRecord::Schema.define(:version => 20140612022826) do
 
   create_table "activities", :force => true do |t|
     t.integer  "trackable_id"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(:version => 20140523152217) do
     t.integer  "duration"
     t.datetime "start_time"
     t.datetime "end_time"
+    t.text     "metadata"
     t.text     "data"
     t.integer  "user_id"
     t.integer  "kind_id"


### PR DESCRIPTION
Concerto currently does not have a good way of storing metadata about a given piece of content.

As a starting point, the metadata column can either represent free-form data or a foreign key for a separate data store that contains more metadata about the content.

Since screens don't usually ask for this data, we don't actually need to store it in the Concerto database itself.
