### PR TITLE
Adds optional locals hash when rendering view hooks for plugins

### DIFF
--- a/app/models/concerto_plugin.rb
+++ b/app/models/concerto_plugin.rb
@@ -98,7 +98,7 @@ class ConcertoPlugin < ActiveRecord::Base
   # string.
   # This is very inefficient, especially for multiple hooks in one view.
   # However, the API is implementation-agnostic.
-  def self.render_view_hook(context, hook_name)
+  def self.render_view_hook(context, hook_name, local_options = nil)
     result = ""
     controller_name = context.controller.controller_name
     ConcertoPlugin.enabled.each do |plugin|
@@ -107,7 +107,7 @@ class ConcertoPlugin < ActiveRecord::Base
           # Make the authorization rules from the plugin available
           context.controller.switch_to_plugin_ability(plugin.mod)
           if hook[:type] == :partial
-            result += context.render :partial => hook[:hook]
+            result += context.render :partial => hook[:hook], :locals => local_options
           elsif hook[:type] == :text
             result += hook[:hook]
           elsif hook[:type] == :proc

--- a/app/views/contents/_form_middle.html.erb
+++ b/app/views/contents/_form_middle.html.erb
@@ -16,7 +16,7 @@
 
 </fieldset>
 
-<%= ConcertoPlugin.render_view_hook self, :content_form %>
+<%= ConcertoPlugin.render_view_hook self, :content_form, {:form => form} %>
 
 <fieldset>
   <legend><span><%=t('contents.submit_to_feeds')%></span></legend>

--- a/config/locales/views/elements/en.yml
+++ b/config/locales/views/elements/en.yml
@@ -32,5 +32,5 @@ en:
 
     owner_select:
       no_users_found: 'No users found.'
-      select_user: 'Select a User ...'
+      select_user: 'Select a User...'
       type_to_filter: 'Type to filter ...'


### PR DESCRIPTION
Example use case: passing a form helper object to a plugin view while making concerto_content_scheduling plugin. Needed in order to use recurring_select and to save the associated schedule with the new content. 
