### PR TITLE
extend plugin and plugin info to allow for extending models

### DIFF
--- a/app/models/concerto_plugin.rb
+++ b/app/models/concerto_plugin.rb
@@ -148,6 +148,22 @@ class ConcertoPlugin < ActiveRecord::Base
     end
   end
 
+  # Extends models by including modules (preferably ActiveSupport::Concern)
+  def self.extend_models
+    ConcertoPlugin.enabled.each do |plugin|
+      info = plugin.plugin_info
+      next if info.nil? || info.model_extensions.nil?
+
+      info.model_extensions.each do |model, extensions|
+        model.class_eval do
+          extensions.each do |extension|
+            include extension
+          end
+        end
+      end
+    end
+  end
+
 private
 
   #custom validation for plugin URLs

--- a/config/initializers/12-plugins.rb
+++ b/config/initializers/12-plugins.rb
@@ -23,6 +23,10 @@ if ActiveRecord::Base.connection.table_exists? 'concerto_plugins'
       end
     end
   end
+
+  Rails.application.config.to_prepare do
+    ConcertoPlugin.extend_models
+  end
 end
 
 Rails.logger.debug "Completed 12-plugins.rb at #{Time.now.to_s}"

--- a/lib/concerto/plugin_info.rb
+++ b/lib/concerto/plugin_info.rb
@@ -17,6 +17,7 @@ module Concerto
     attr_reader :mount_points
     attr_reader :configs
     attr_reader :init_block
+    attr_reader :model_extensions
 
     # Configuration API: Accessible by the engine via "new"
 
@@ -90,6 +91,13 @@ module Concerto
         :type => mytype,
         :hook => myhook
       }
+    end
+
+    # Extend the given model by including a ActiveSupport::Concern
+    def extend_model(model, extension)
+      @model_extensions ||= {}
+      @model_extensions[model] ||= []
+      @model_extensions[model] << extension
     end
 
     # Info Reading API


### PR DESCRIPTION
fixes #1014

Example: 

```
module ConcertoCustomPlugin
  class Engine < ::Rails::Engine
    isolate_namespace ConcertoStatistics
    engine_name "statistics"

    def plugin_info(plugin_info_class)
      @plugin_info ||= plugin_info_class.new do
          extend_model(Screen, ConcertoCustomPlugin::Concerns::AddCustomizationToScreen)
        end
      end
    end
  end
end
```

```
module ConcertoCustomPlugin
  module Concerns
    module AddCustomizationToScreen
      extend ActiveSupport::Concern
      included do
        has_many :things, :class_name => 'ConcertoCustomPlugin::Thing', :dependent => :destroy
      end
    end
  end
end
```
