### PR TITLE
add content sidebar view hook

### DIFF
--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -1,77 +1,101 @@
-<section class="viewblock">
-  <header class="viewblock-header">
-    <div class="viewblock-header_right">
-      <div class="button-padding">
-        <% if can? :update, @content %>
-          <%= link_to t(:edit_model, :model => Content), edit_content_path(@content), :class => "btn" %>
-        <% end %>
-        <% if can? :delete, @content %>
-          <%= link_to t(:destroy_model, :model => Content), @content, :data => { :confirm => t(:are_you_sure_delete_model_key, :model => Content.model_name.human, :key => @content.name) }, :method => :delete, :class => "btn" %>
-        <% end %>
-      </div>
-    </div>
+<% sidebar = ConcertoPlugin.render_view_hook self, :content_sidebar, :locals => { :content => @content } %>
 
-    <div class="default-padding">
-      <h1>
-        <%= link_to possessive(@content.user.name.strip) + " " + Content.model_name.human.pluralize, @content.user %> &gt; 
-        <%= @content.name %>
-      </h1>
-    </div>
-  </header>
-  <div class="viewblock-cont">
+<%
+   # Hide details sidebar when there is nothing to show
+   content_span = 9
+   sidebar_span = 3
+   if sidebar.blank?
+     content_span = 12
+     sidebar_span = 0
+   end
+%>
 
-    <div class="row-fluid">
-      <div class="span2 content-details">
+<div class="row-fluid">
+  <div class="span<%= content_span %>">
+
+    <section class="viewblock">
+      <header class="viewblock-header">
+        <div class="viewblock-header_right">
+          <div class="button-padding">
+            <% if can? :update, @content %>
+              <%= link_to t(:edit_model, :model => Content), edit_content_path(@content), :class => "btn" %>
+            <% end %>
+            <% if can? :delete, @content %>
+              <%= link_to t(:destroy_model, :model => Content), @content, :data => { :confirm => t(:are_you_sure_delete_model_key, :model => Content.model_name.human, :key => @content.name) }, :method => :delete, :class => "btn" %>
+            <% end %>
+          </div>
+        </div>
 
         <div class="default-padding">
-
-          <div class="subblock">
-            <p class="uppercase"><small><b><%= t('.display_from') %></b></small></p>
-            <% if !@content.start_time.nil? %>
-              <p><%= l @content.start_time, :format => :short_day %><br /><%= l @content.start_time, :format => :twelve_hour_time %></p>
-            <% else %>
-              <p><%= t('.the_dawn_of_time') %></p>
-            <% end %>
-            <p class="uppercase"><small><b><%= t('.display_until') %></b></small></p>
-            <% if !@content.end_time.nil? %>
-              <p><%= l @content.end_time, :format => :short_day %><br /><%= l @content.end_time, :format => :twelve_hour_time %></p>
-            <% else %>
-              <p><%= t '.the_end_of_time' %></p>
-            <% end %>
-          </div>
-
-          <div class="subblock">
-            <p class="uppercase"><small><b><%= t('.submitted_by') %></b></small></p>
-            <p><%= link_to @user.name, @user %></p>
-          </div>
-          
-          <div class="subblock">
-            <p class="uppercase"><small><b><%= t('.feeds_moderation_status') %></b></small></p>
-            <% if @content.submissions.all.count > 0 %>
-              <ul>
-                <% @content.submissions.all.each do |submission| %>
-                  <li><%= link_to submission.feed.name, [submission.feed, submission] %> - <%= submission.moderation_text %></li>
-                <% end %> 
-              </ul>
-            <% else %>
-              <%= t('.not_submitted') %>
-            <% end %>
-          </div>
-
-          <%= ConcertoPlugin.render_view_hook self, :content_details %>
-        
-          <%= render :partial => 'dynamic_content_tools', :locals => { :content => @content } if @content.is_a?(DynamicContent) && can?(:edit, @content) %>
+          <h1>
+            <%= link_to possessive(@content.user.name.strip) + " " + Content.model_name.human.pluralize, @content.user %> &gt;
+            <%= @content.name %>
+          </h1>
         </div>
- 
-      </div>
+      </header>
+      <div class="viewblock-cont">
 
-      <div class="span10">
-        <div class="default-padding">
-          <%= render_content(@content) %>
+        <div class="row-fluid">
+          <div class="span2 content-details">
+
+            <div class="default-padding">
+
+              <div class="subblock">
+                <p class="uppercase"><small><b><%= t('.display_from') %></b></small></p>
+                <% if !@content.start_time.nil? %>
+                  <p><%= l @content.start_time, :format => :short_day %><br /><%= l @content.start_time, :format => :twelve_hour_time %></p>
+                <% else %>
+                  <p><%= t('.the_dawn_of_time') %></p>
+                <% end %>
+                <p class="uppercase"><small><b><%= t('.display_until') %></b></small></p>
+                <% if !@content.end_time.nil? %>
+                  <p><%= l @content.end_time, :format => :short_day %><br /><%= l @content.end_time, :format => :twelve_hour_time %></p>
+                <% else %>
+                  <p><%= t '.the_end_of_time' %></p>
+                <% end %>
+              </div>
+
+              <div class="subblock">
+                <p class="uppercase"><small><b><%= t('.submitted_by') %></b></small></p>
+                <p><%= link_to @user.name, @user %></p>
+              </div>
+
+              <div class="subblock">
+                <p class="uppercase"><small><b><%= t('.feeds_moderation_status') %></b></small></p>
+                <% if @content.submissions.all.count > 0 %>
+                  <ul>
+                    <% @content.submissions.all.each do |submission| %>
+                      <li><%= link_to submission.feed.name, [submission.feed, submission] %> - <%= submission.moderation_text %></li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <%= t('.not_submitted') %>
+                <% end %>
+              </div>
+
+              <%= ConcertoPlugin.render_view_hook self, :content_details %>
+
+              <%= render :partial => 'dynamic_content_tools', :locals => { :content => @content } if @content.is_a?(DynamicContent) && can?(:edit, @content) %>
+            </div>
+
+          </div>
+
+          <div class="span10">
+            <div class="default-padding">
+              <%= render_content(@content) %>
+            </div>
+          </div>
+
         </div>
-      </div>
 
+      </div>
+    </section>
     </div>
-    
-  </div>
-</section>
+
+    <% if !sidebar.blank? %>
+        <div class="span<%= sidebar_span %>">
+          <%= sidebar %>
+        </div>
+    <% end %>
+
+</div>


### PR DESCRIPTION
Adds a view hook to display a sidebar on the content view on the right side, similar to the screen view. 
This is not to be confused by the content details section, which is on the left of the content
