### PR TITLE
fix group header translations

### DIFF
--- a/app/views/groups/_show_body.html.erb
+++ b/app/views/groups/_show_body.html.erb
@@ -44,7 +44,7 @@
 <div class="clearfix default-padding">
   <div class="header-with-icon">
     <h3>
-      <%= t '.feed_header', :number => @group.feeds.count, :count => @group.feeds.count %>
+      <%= t '.feed_header', :count => @group.feeds.count %>
     </h3>
   </div>
 </div>
@@ -108,7 +108,7 @@
 <div class="clearfix default-padding">
   <div class="header-with-icon">
     <h3>
-      <%= t('.member_header', :number => total_members, :s_display => total_members == 1 ? '' : 's') %>
+      <%= t '.member_header', :count => total_members %>
     </h3>
   </div>
   <br/>

--- a/config/locales/views/groups/en.yml
+++ b/config/locales/views/groups/en.yml
@@ -49,7 +49,7 @@ en:
       edit_group: 'Edit Group'
       feed_header:
         one: 'Moderates one Feed'
-        other: 'Moderates %{number} Feeds'
+        other: 'Moderates %{count} Feeds'
       group_description: 'Group Description'
       group_has_no_leaders: 'This group currently has no leaders.  You should promote a regular member in the table above.'
       group_leaders: 'Group Leaders'
@@ -57,7 +57,9 @@ en:
       leader: 'Leader'
       leave_group: 'Leave Group'
       member: ' member'
-      member_header: 'Contains %{number} Member%{s_display}'
+      member_header:
+        one:  'Contains one Member'
+        other: 'Contains %{count} Members'
       no_pending_approvals: 'No Pending Approvals!'
       not_in_group: "You are not currently in this group."
       promote_to_leader: "Promote to Leader"

--- a/config/locales/views/groups/fr.yml
+++ b/config/locales/views/groups/fr.yml
@@ -33,10 +33,9 @@ fr:
       update_permissions: "Mettre les permissions à jour"
     show_body: 
       edit_group: "Editer le groupe"
-      feed_header: "Modère %{number} Fils%{s_display}"
       feed_header:
         one: 'Modère un Fils'
-        many: "Modère %{number} Fils"
+        many: "Modère %{count} Fils"
       group_description: "Description du groupe"
       group_has_no_leaders: "Ce groupe n'a actuellment pas de chef.  Vous devriez promouvoir un des membres régulier."
       group_leaders: "Chef de groupe"
@@ -45,7 +44,9 @@ fr:
       leader: Chef
       leave_group: "Quitter le groupe"
       member: " Membre"
-      member_header: "Contient %{number} Membres%{s_display}"
+      member_header: 
+        one: "Contient un Membre"
+        many: "Contient %{count} Membres"
       no_pending_approvals: "Pas d'approbation en attente!"
       no_regular_members: "Ce groupe n'a actuellement pas d'utilisateur régulier."
       not_in_group: "Vous n'êtes pas actuellment dans ce groupe."
@@ -55,7 +56,7 @@ fr:
       request_made_at: "Requête faite à"
       screen_header:
         one: "Gère un Ecran"
-        many: "Gère %{number} Ecrans"
+        many: "Gère %{count} Ecrans"
       your_membership_role: "Vous êtes actuelllement  %{level}%{what} de ce groupe."
     show_header: 
       group_cannot_be_deleted: "Le groupe ne peut pas être supprimé"


### PR DESCRIPTION
i18n pluralization says `:count` is the interpolation variable to use, not `:number`... also removed the manual pluralization from the members header.
