### PR TITLE
Fix time duration slider

### DIFF
--- a/app/assets/javascripts/rangeinput.js
+++ b/app/assets/javascripts/rangeinput.js
@@ -132,7 +132,7 @@
     }
 
     function hasEvent(el) {
-        var e = el.data("events");
+        var e = $._data(el[0], "events");
         return e && e.onSlide;
     }
 


### PR DESCRIPTION
When sliding the time duration slider, the time was not updated during sliding, making it really hard to set the desired time duration. 
(for underlying problem see: https://github.com/jquerytools/jquerytools/issues/887)
