### PR TITLE
define template position ordering

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -9,7 +9,7 @@ class Template < ActiveRecord::Base
 
   has_many :screens, :dependent => :restrict
   has_many :media, :as => :attachable, :dependent => :destroy
-  has_many :positions, :dependent => :destroy
+  has_many :positions, :dependent => :destroy, :order => :id
   
   accepts_nested_attributes_for :media
   accepts_nested_attributes_for :positions, :allow_destroy => true


### PR DESCRIPTION
We have played around with templates that were using overlapping positions (one on top of another). All of a sudden the order of those position changed which broke the template

This fix makes the order deterministic. 

The best solution would be if the positions can be manually ordered, but this functionality might only be beneficial for a really small set of use cases, and given the fact that you can work around a missing manual ordering by creating the positions one after another (or switching the config between existing positions), this fix should be sufficient.
