### PR TITLE
add support for multiple content medias

### DIFF
--- a/app/assets/javascripts/graphics.js.erb
+++ b/app/assets/javascripts/graphics.js.erb
@@ -21,7 +21,7 @@ var initializeGraphicPreview = {
           iframe: true,
           type: 'POST',
         }).complete(function(data) {
-          media_id.val(data.responseJSON.id);
+          media_id.val(data.responseJSON[0].id);
           var img_string = "<img src='<%= Rails.application.config.relative_url_root %>/content/preview/display?media_id=" + media_id.val() + "&type=Graphic&width=" + preview.width() + "' />";
           preview.html(img_string);
         }).error(function() {


### PR DESCRIPTION
The content model already supports having multiple media attached to it, but until now, the controllers did not support it. This PR extends the content and media controller to allow attaching multiple media's to content
