### PR TITLE
make google analytics work with turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,5 +87,6 @@ gem 'concerto_docsplit'
 
 # NProgress provides progress bars for pages loaded via Turbolinks
 gem 'nprogress-rails', '~> 0.1.6.3'
+gem 'google-analytics-turbolinks', '~> 0.0.4'
 
 gem 'i18n-tasks', '~> 0.4.5', :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     girl_friday (0.11.2)
       connection_pool (~> 1.0)
       rubinius-actor
+    google-analytics-turbolinks (0.0.4)
     google-api-client (0.7.1)
       addressable (>= 2.3.2)
       autoparse (>= 0.3.3)
@@ -250,6 +251,7 @@ DEPENDENCIES
   execjs (~> 2.2.2)
   foreman
   girl_friday
+  google-analytics-turbolinks (~> 0.0.4)
   i18n-tasks (~> 0.4.5)
   jquery-rails
   jquery-timepicker-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,5 +22,6 @@
 //= require jquery.datepair.js
 //= require jquery.iframe-transport
 //= require_tree .
-#= require nprogress
-#= require nprogress-turbolinks
+//= require nprogress
+//= require nprogress-turbolinks
+//= require google-analytics-turbolinks


### PR DESCRIPTION
until now only the initial page load was tracked because turbolinks prevent the whole page from loading again, thus google analytics did not know anything about the following navigations
