### PR TITLE
fixes #1148 use to_hash instead of to_h

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -39,7 +39,7 @@ class MediaController < ApplicationController
 
   private
 
-  def get_file_params(h = params.permit!.to_h)
+  def get_file_params(h = params.permit!.to_hash)
     files = []
     h.each do |k,v|
       value = v || k


### PR DESCRIPTION
Since some users don't have the versions needed for to_h  (see #1148)
