### PR TITLE
Permission / visibility fixes

### DIFF
--- a/app/views/feeds/moderate.html.erb
+++ b/app/views/feeds/moderate.html.erb
@@ -12,9 +12,9 @@
   </header>
   <div id="browse-body" class="viewblock-cont">
     
-    <% if @feeds.count > 0 %>
+    <% if @feeds.length > 0 %>
       <div class="default-padding">
-        <h2><%= pluralize(@feeds.count, Feed.model_name.human) %> <%= t('.with_pending_content') %></h2>
+        <h2><%= pluralize(@feeds.length, Feed.model_name.human) %> <%= t('.with_pending_content') %></h2>
       </div>
 
       <ul class="list-stacked">

--- a/app/views/groups/_show_body.html.erb
+++ b/app/views/groups/_show_body.html.erb
@@ -22,7 +22,7 @@
             <div class="default-padding clearfix">
               <% if already_member %>
                   <% membership = Membership.where(:group_id => @group.id, :user_id => current_user.id).first %>
-                  <% if @group.has_member?(current_user) %>
+                  <% if @group.has_member?(current_user) && can?(:delete, membership) %>
                       <%= link_to(t('.leave_group'), group_membership_path(:group_id => @group.id, :id => membership.id), :method => :delete, :class => "btn pull-right", :data => {:confirm => t(:are_you_sure_leave_group, :group => @group.name)}) %>
                   <% end %>
                   <p>


### PR DESCRIPTION
- Another usage of ```count``` that ignored the ability / visible feeds by the user (count performs counting on database level which ignores cancan user abilities)
- Check if user can delete membership for showing leave group button