### PR TITLE
fix template preview image updating when it is modified

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -75,11 +75,17 @@ class Template < ActiveRecord::Base
   # template, fields, and original media.  Return the largest update_at value.
   def last_modified
     timestamps = [updated_at]
-    latest_position = positions.order('updated_at DESC').first
+    latest_position = positions.reorder('updated_at DESC').first
     timestamps.append(latest_position.updated_at) unless latest_position.nil?
     latest_media = media.original.order('updated_at DESC').first
     timestamps.append(latest_media.updated_at) unless latest_media.nil?
     return timestamps.max
+  end
+
+  # for cachebusting
+  def last_modified_md5
+    require 'digest/md5'
+    Digest::MD5.hexdigest(last_modified.to_s)
   end
 
   # Generate a preview image of a template.

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -42,7 +42,7 @@
 
   <fieldset>
     <div class="clearfix">
-      <%= image_tag preview_template_path(@template, :width=> 400, :format => :jpg) %>
+      <%= image_tag preview_template_path(@template, :lm => @template.last_modified_md5, :width=> 400, :format => :jpg) %>
     </div>
   </fieldset>
 

--- a/app/views/templates/_show_body.html.erb
+++ b/app/views/templates/_show_body.html.erb
@@ -1,5 +1,5 @@
 <article>
-  <%= image_tag preview_template_path(@template, :width=> 600, :format => :jpg), :style => "width: 100%", :alt => t('.preview_alt', :name => @template.name) %>
+  <%= image_tag preview_template_path(@template, :width=> 600, :lm => @template.last_modified_md5, :format => :jpg), :style => "width: 100%", :alt => t('.preview_alt', :name => @template.name) %>
 </article>
 <aside class="default-padding">
   <p>


### PR DESCRIPTION
Fixes #1180.  Had to use reorder to override the ordering specified in the relation, and incorporated the md5 hash of the last modified field into the preview image for cache busting.