### PR TITLE
Disable concerto plugin select field when installing via rubygems

### DIFF
--- a/app/assets/javascripts/concerto_plugins.js
+++ b/app/assets/javascripts/concerto_plugins.js
@@ -8,6 +8,7 @@ function toggleFields()
         if (source == 'rubygems') {
             $(url_field).closest('div.clearfix').hide();
             $(name_select).closest('div.clearfix').hide();
+            $(name_select).prop('disabled', true);
             $(name_box).closest('div.clearfix').show();
             $(name_box).focus();
         }
@@ -15,6 +16,7 @@ function toggleFields()
             $(name_box).closest('div.clearfix').hide();
             $(url_field).closest('div.clearfix').hide();
             $(name_select).closest('div.clearfix').show();
+            $(name_select).prop('disabled', false);
             $(name_select).focus();
         }
         else {


### PR DESCRIPTION
#1220 

Seems like the drop down menu value was still submitted when switching to the RubyGems text field. This caused two gem names to be submitted as pointed out in the original issue. I just added a quick change to disable the select input when using RubyGems as a source. 