### PR TITLE
Add screen's time zone UTC offset to frontend setup.js

### DIFF
--- a/app/controllers/frontend/screens_controller.rb
+++ b/app/controllers/frontend/screens_controller.rb
@@ -154,12 +154,14 @@ class Frontend::ScreensController < ApplicationController
           end
         end
       end
+      # temporarily change time zone string representation to integer utc offset
+      @screen.time_zone = Time.now.in_time_zone(@screen.time_zone).utc_offset
 
       if stale?(etag: @screen.frontend_cache_key(field_configs), public: true)
       respond_to do |format|
         format.json {
           render json: @screen.to_json(
-            only: [:name, :id],
+            only: [:name, :id, :time_zone],
             include: {
               template: {
                 include: {


### PR DESCRIPTION
This will add the UTC offset for the screen's time zone (in seconds and adjusting for DST) to the frontend setup.js. The frontend can then use this time offset to adjust the time field to match the screen's configured time zone. 