### PR TITLE
include js in frontend

### DIFF
--- a/app/assets/javascripts/frontend/application.js
+++ b/app/assets/javascripts/frontend/application.js
@@ -1,0 +1,2 @@
+//= require jquery
+//= require_tree .

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Concerto - <%= content_for?(:title) ? yield(:title) : "Open Source Digital Signage" %></title>
   <%= stylesheet_link_tag 'frontend/application' %>
+  <%= javascript_include_tag 'frontend/application' %>
   <%= csrf_meta_tag %>
   <meta name="apple-mobile-web-app-capable" content="yes"/>
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
@@ -11,6 +12,6 @@
   <%= content_for(:head) -%>
 </head>
 <body>
-<%= yield %>
+<%= yield -%>
 </body>
 </html>


### PR DESCRIPTION
This is related to concerto/concerto-frontend#47 but not dependent upon it.  From what I could tell, the screen_setup js was not being included in the frontend, so I don't think it was polling when a temp token was being used like it should have been. 