### PR TITLE
Frontend cache key update

### DIFF
--- a/app/controllers/frontend/contents_controller.rb
+++ b/app/controllers/frontend/contents_controller.rb
@@ -44,7 +44,7 @@ class Frontend::ContentsController < ApplicationController
       logger.warn e.message
     end
 
-    response.headers["X-Concerto-Frontend-Setup-Key"] = Digest::MD5.hexdigest(@screen.frontend_cache_key)
+    response.headers["X-Concerto-Frontend-Setup-Key"] = Digest::MD5.hexdigest(@screen.frontend_cache_key(@screen.template.media))
 
     respond_to do |format|
       format.json {

--- a/app/controllers/frontend/contents_controller.rb
+++ b/app/controllers/frontend/contents_controller.rb
@@ -44,7 +44,7 @@ class Frontend::ContentsController < ApplicationController
       logger.warn e.message
     end
 
-    response.headers["X-Concerto-Frontend-Setup-Key"] = Digest::MD5.hexdigest(@screen.frontend_cache_key(@screen.template.media))
+    response.headers["X-Concerto-Frontend-Setup-Key"] = Digest::MD5.hexdigest(@screen.frontend_cache_key)
 
     respond_to do |format|
       format.json {

--- a/app/controllers/frontend/screens_controller.rb
+++ b/app/controllers/frontend/screens_controller.rb
@@ -157,7 +157,7 @@ class Frontend::ScreensController < ApplicationController
 
       @screen.time_zone = ActiveSupport::TimeZone::MAPPING[@screen.time_zone]
 
-      if stale?(etag: @screen.frontend_cache_key(field_configs), public: true)
+      if stale?(etag: @screen.frontend_cache_key, public: true)
       respond_to do |format|
         format.json {
           render json: @screen.to_json(

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -262,6 +262,9 @@ class Screen < ActiveRecord::Base
         end
       end
     end
+    self.template.media.each do |m|
+      max_updated_at = [m.updated_at.try(:utc).try(:to_i), max_updated_at].max
+    end
     args.each do |ao|
       if ao.respond_to? 'updated_at'
         max_updated_at = [ao.updated_at.try(:utc).try(:to_i), max_updated_at].max

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -261,10 +261,18 @@ class Screen < ActiveRecord::Base
           max_updated_at = [field_config.updated_at.try(:utc).try(:to_i),max_updated_at].max
         end
       end
-  end
+    end
     args.each do |ao|
-      if ao.methods.include? 'updated_at'
+      if ao.respond_to? 'updated_at'
         max_updated_at = [ao.updated_at.try(:utc).try(:to_i), max_updated_at].max
+      else
+        if ao.respond_to? 'each'
+          ao.each do |aso|
+            if aso.respond_to? 'updated_at'
+              max_updated_at = [aso.updated_at.try(:utc).try(:to_i), max_updated_at].max
+            end
+          end
+        end
       end
     end
     return "frontend-screen/#{self.id}-#{self.template.id}-#{max_updated_at}"


### PR DESCRIPTION
partial fix for concerto/concerto-frontend#50.  Includes media change detection and fixes a bug where passed arrays or associations were not having their updated_at property checked.