### PR TITLE
send sample email during configuration check

### DIFF
--- a/app/controllers/concerto_config_controller.rb
+++ b/app/controllers/concerto_config_controller.rb
@@ -22,6 +22,15 @@ class ConcertoConfigController < ApplicationController
     @rails_log_perms = File.stat(Rails.root.join('log')).mode.to_s(8)[-3,3] == "600" #should be 600 on a shared box
     @rails_tmp_perms = File.stat(Rails.root.join('tmp')).writable?
     @webserver_ownership = File.stat(Rails.root).owned?
+
+    unless ConcertoConfig["mailer_from"].blank?
+      begin
+        ActivityMailer.test_email(current_user.email).deliver
+      rescue StandardError => e
+        Rails.logger.error(e)
+        flash[:notice] = t('.unable_to_send_test_email')
+      end
+    end
   end
 
   # get a hash of concerto_config keys and values and update them using the ConcertoConfig setter

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -5,4 +5,11 @@ class ActivityMailer < ActionMailer::Base
       mail to: @activity.recipient.email, subject: "Your Concerto Submission: #{@activity.trackable.content.name} has been #{@activity.parameters[:status] ? "approved" : "denied"}", from: @activity.owner.email
     end
   end
+
+  def test_email(to)
+    mail to: to, 
+      subject: t('.subject'), 
+      body: t('.body'),
+      from: ConcertoConfig[:mailer_from]
+  end
 end

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -3,6 +3,15 @@ en:
   smtp_send_error_ssl: "A SMTP error occurred while sending a notification e-mail. Please check the Concerto SMTP settings-- you might need to disable SSL Verification."
   asset_precomp_failed: "Asset precompilation failed. Please make sure the command rake assets:precompile works."
 
+  activity_mailer:
+    test_email:
+      subject: 'Email Configuration Test'
+      body: 'This is a sample email sent from Concerto.  If you received it, then your email settings are apparently configured properly.'
+
+  concerto_config:
+    config_check:
+      unable_to_send_test_email: 'Unable to send test email'
+
   #Contents controller
   missing_default_type: "Missing Default Content Type"
   unrecognized_type: "Unrecognized content type."


### PR DESCRIPTION
A sample email is only sent if the mailer_from config field is not empty.