### PR TITLE
fixes #1288 generate ETag for content

### DIFF
--- a/app/controllers/frontend/contents_controller.rb
+++ b/app/controllers/frontend/contents_controller.rb
@@ -45,6 +45,7 @@ class Frontend::ContentsController < ApplicationController
     end
 
     response.headers["X-Concerto-Frontend-Setup-Key"] = Digest::MD5.hexdigest(@screen.frontend_cache_key)
+    response.headers["ETag"] = Digest::MD5.hexdigest(@screen.frontend_cache_key + @content.collect{|e| e.id}.to_s)
 
     respond_to do |format|
       format.json {


### PR DESCRIPTION
This resolves the screen flicker caused by cached content holding a stale X-Concerto-Frontend-Setup-Key header value, by generating an ETag for each content.json request that consists of the value of the screen's frontend_cache_key plus the id's of the content in the payload (since content cannot actually change once it has been submitted, this should be sufficient).