### PR TITLE
Make frontend fields stateless to resolve repeating content issues.

### DIFF
--- a/app/controllers/frontend/contents_controller.rb
+++ b/app/controllers/frontend/contents_controller.rb
@@ -22,19 +22,14 @@ class Frontend::ContentsController < ApplicationController
 
     shuffle_config = FieldConfig.get(@screen, @field, 'shuffler') || DEFAULT_SHUFFLE
     shuffler_klass = FrontendContentOrder.load_shuffler(shuffle_config)
-    session_key = "frontend_#{@screen.id}_#{@screen.template.id}_#{@field.id}_#{shuffler_klass}".to_sym
     shuffler = nil
-    count = 1
-
-    count = 20 if FieldConfig.get(@screen, @field, 'marquee') == '1'
 
     run_callbacks :index do # Run plugin hooks
-      shuffler = shuffler_klass.new(@screen, @field, @subscriptions, session[session_key])
-      @content = shuffler.next_contents(count)
+      shuffler = shuffler_klass.new(@screen, @field, @subscriptions)
+      @content = shuffler.next_contents()
     end
 
     auth! object: @content
-    session[session_key] = shuffler.save_session()
 
     begin
       @content.each do |c|

--- a/lib/base_shuffle.rb
+++ b/lib/base_shuffle.rb
@@ -7,40 +7,19 @@ class BaseShuffle
   # @param [Screen] screen Screen showing the content.
   # @param [Field] field Field showing the content.
   # @param [Array<Subscription>] subscriptions All the subscriptions to use.
-  # @param [Array<Integer>] store Array to store a timeline if needed.
   # @param [Hash] options Any additional options. 
-  def initialize(screen, field, subscriptions, store=[], options={})
+  def initialize(screen, field, subscriptions, options={})
     @screen = screen
     @field = field
     @subscriptions = subscriptions
-    @store = store
     @options = options
-
-    @store = [] if @store.nil?
   end
 
   # Return the next set content to be shown.
   #
-  # @param [Integer] count Number of content needed, defaults to 1.
   # @return [Array<Content>] Next content that should be rendered.
-  def next_contents(count=1)
-    if @store.length < count
-      content = content()
-      @store += content.collect{|c| c.id}
-    end
-    return [] if @store.empty?
-
-    content_ids = @store.shift(count)
-    Content.where(id: content_ids).to_a.compact
-  end
-
-  # Return a timeline to be saved.
-  # Since we can't directly access the session, the controller
-  # will pull here for what should be saved.
-  #
-  # @return [Array<Integer>] Array of content ids in the timeline.
-  def save_session()
-    @store
+  def next_contents()
+    content.to_a.compact
   end
 
   private

--- a/lib/weighted_shuffle.rb
+++ b/lib/weighted_shuffle.rb
@@ -6,15 +6,8 @@ require 'base_shuffle'
 # then jumbled up and served from a timeline.
 class WeightedShuffle < BaseShuffle
 
-  def next_contents(count=1)
-    if @store.length < count
-      content = weighted_content()
-      @store += content.collect{|c| c.id}
-    end
-    return [] if @store.empty?
-
-    content_ids = @store.shift(count)
-    Content.where(id: content_ids).to_a.compact
+  def next_contents()
+    weighted_content.to_a.compact
   end
 
   private


### PR DESCRIPTION
This eliminates the concept of a store for timeline data, which was just going to the client anyway when cookie store was enabled. Instead, the entire timeline worth of content will be sent to the client. This timeline is not reliant on getting a cookie back which could have been overwritten in the client by a simultaneous request.

This will also have the side effects of reducing overall requests to the server, reducing the size of cookies that need to be sent to the server with each request, and reducing the overall number of queries from each screen for a given period of time.

If a reliable store for this data is found, the store concept could be reinstated. However the only reason for this would seem to be if the client could not store the whole timeline, which seems unlikely.

This seems to be effective in testing on my local box. If other folks are OK with the approach (@augustf @mfrederickson @gbprz) , we should test and merge. This would close #1329.