### PR TITLE
plugin update feedback and alternate assets precompile

### DIFF
--- a/app/assets/javascripts/concerto_plugins.js
+++ b/app/assets/javascripts/concerto_plugins.js
@@ -63,7 +63,7 @@ function updatePluginSuccess(e, data, status, xhr) {
     msg = msg + '</div>';
     $('#updatePluginResults').html(msg);
   } else {
-    window.location.replace(data['redirect_to']);
+    window.location.reload(true);
   }
 }
 

--- a/app/assets/javascripts/concerto_plugins.js
+++ b/app/assets/javascripts/concerto_plugins.js
@@ -39,6 +39,32 @@ function bindListeners() {
   $('select#concerto_plugin_source').change(toggleFields);
   // since the default source is rubygems, hide the source url on load
   $('select#concerto_plugin_source').trigger('change');
+
+  $('a.update-plugin-btn').on('ajax:beforeSend', updatePluginBeforeSend);
+  $('a.update-plugin-btn').on('ajax:success', updatePluginSuccess);
+  $('a.update-plugin-btn').on('ajax:error', updatePluginError);
+}
+
+function updatePluginBeforeSend(e, data, status, xhr) {
+  $('#updatePluginResults').html('<span class="fa fa-spinner fa-spin"></span> Updating...');
+}
+
+function updatePluginError(e, data, status, xhr) {
+  $('#updatePluginResults').html('<div class="alert alert-warning">Unable to update plugin.</br><pre>' + status + '</pre></div>');
+}
+
+function updatePluginSuccess(e, data, status, xhr) {
+  var msg = '';
+  if (!data['bundle_success'] || !data['rake_success']) {
+    msg = '<div class="alert alert-warning">Unable to update plugin.</br><pre>' + data['bundle_output'] + '</pre><br/>';
+    if (data['rake_output'] != null) {
+      msg = msg + '<pre>' + data['rake_output'] + '</pre><br/>';
+    }
+    msg = msg + '</div>';
+    $('#updatePluginResults').html(msg);
+  } else {
+    window.location.replace(data['redirect_to']);
+  }
 }
 
 $(document).ready(bindListeners);

--- a/app/controllers/concerto_plugins_controller.rb
+++ b/app/controllers/concerto_plugins_controller.rb
@@ -106,14 +106,22 @@ class ConcertoPluginsController < ApplicationController
   end
 
   def update_gem
+    results = {}
     plugin = ConcertoPlugin.find(params[:id])
-    system('bundle update', plugin.gem_name)
-    rake_precompile()
-    restarted = restart_webserver()
-    if restarted
-      flash[:notice] = t(:plugin_updated)
+    results[:bundle_output] = `bundle update #{plugin.gem_name}`
+    results[:bundle_success] = $?.success?
+
+    if results[:bundle_success]
+      results[:rake_output] = `bundle exec rake assets:precompile`#rake_precompile()
+      results[:rake_success] = $?.success?
+      restarted = restart_webserver()
+      if restarted
+        results[:notice] = t(:plugin_updated)
+        flash[:notice] = t(:plugin_updated)
+      end
+      results[:redirect_to] = concerto_plugin_path(plugin)
     end
-    redirect_to action: :show, id: plugin.id
+    render json: results
   end
 
   def write_Gemfile

--- a/app/controllers/concerto_plugins_controller.rb
+++ b/app/controllers/concerto_plugins_controller.rb
@@ -108,7 +108,7 @@ class ConcertoPluginsController < ApplicationController
   def update_gem
     results = {}
     plugin = ConcertoPlugin.find(params[:id])
-    results[:bundle_output] = `bundle update #{plugin.gem_name}`
+    results[:bundle_output] = `bundle update --source #{plugin.gem_name}`
     results[:bundle_success] = $?.success?
 
     if results[:bundle_success]

--- a/app/views/concerto_plugins/show.html.erb
+++ b/app/views/concerto_plugins/show.html.erb
@@ -3,7 +3,7 @@
     <div class="viewblock-header_right">
       <div class="button-padding">
         <% if !@gemspec.nil? && !@rubygems_current_version.nil? && (@rubygems_current_version.to_s > @gemspec.version.to_s) %>
-          <%= link_to t('.upgrade'), update_gem_concerto_plugins_path(id: @concerto_plugin.id),
+          <%= link_to t('.upgrade'), update_gem_concerto_plugin_path(@concerto_plugin),
             class: "btn update-plugin-btn", remote: true %>
         <% end %>
         <% if can? :edit, @concerto_plugin %>

--- a/app/views/concerto_plugins/show.html.erb
+++ b/app/views/concerto_plugins/show.html.erb
@@ -36,7 +36,7 @@
       <p><%= !@gemspec.nil? ? @gemspec.description : "" %></p>
       <p>
         <b><%= t('.gem_version') %></b>
-        <% if @concerto_plugin.gem_version %>
+        <% if @concerto_plugin.gem_version.present? %>
           <%= @concerto_plugin.gem_version %> <%= t('.locked') %>
         <% elsif !@gemspec.nil? %>
           <%= @gemspec.version.to_s %>

--- a/app/views/concerto_plugins/show.html.erb
+++ b/app/views/concerto_plugins/show.html.erb
@@ -3,7 +3,8 @@
     <div class="viewblock-header_right">
       <div class="button-padding">
         <% if !@gemspec.nil? && !@rubygems_current_version.nil? && (@rubygems_current_version.to_s > @gemspec.version.to_s) %>
-          <%= link_to t('.upgrade'), update_gem_concerto_plugins_path(id: @concerto_plugin.id), {method: :post, class: "btn"}%>
+          <%= link_to t('.upgrade'), update_gem_concerto_plugins_path(id: @concerto_plugin.id),
+            class: "btn update-plugin-btn", remote: true %>
         <% end %>
         <% if can? :edit, @concerto_plugin %>
           <%= link_to t(:edit_model, model: ConcertoPlugin.model_name.human), edit_concerto_plugin_path(@concerto_plugin), class: "btn" %>
@@ -50,6 +51,8 @@
         <b><%= t('.installed') %></b>
         <%= (@concerto_plugin.installed? && !@gemspec.nil?) ? t('.installed_yes') : t('.installed_no') %>
       </p>
+    </div>
+    <div id="updatePluginResults" class="default-padding">
     </div>
   </div>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,8 @@ Concerto::Application.routes.draw do
   end
 
   resources :concerto_plugins do
-    collection do
-      post :update_gem
+    member do
+      get :update_gem
     end
   end
 
@@ -44,7 +44,7 @@ Concerto::Application.routes.draw do
     end
     # Special route for CORS preflight requests on #show
     # *** DO NOT EDIT THIS LINE UNLESS YOU KNOW HOW TO TEST IT ***
-    match ':id', controller: :screens, action: 'show_options', via: [:options] 
+    match ':id', controller: :screens, action: 'show_options', via: [:options]
   end
   # End really dangerous routes.
 
@@ -69,9 +69,9 @@ Concerto::Application.routes.draw do
       post :import
     end
   end
-  
+
   resources :fields
-  
+
   resources :screens do
     resources :fields, only: [] do
       resources :subscriptions
@@ -132,7 +132,7 @@ Concerto::Application.routes.draw do
   # Note: 404 errors are not handled by the router.
   # Instead, they are caught by Rails Middleware and then redirected
   # to Concerto's ErrorsController.
-  
+
   resources :pages
 
 end


### PR DESCRIPTION
Addresses #1345 when upgrading a plugin... handles gem update async and provides more detailed feedback when bundle update fails or the assets precompile fails.  @augustf I changed the rake task to run from a system call so we could capture the output and success result-- don't know if that's a problem or not.  Seems to work fine for me in development, but a better test would be on a deployed environment.  

Please test this in your environments before you merge it.  Thanks.