### PR TITLE
lock turbolinks at 2.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'uglifier', '~> 2.7.2'
 gem 'bootstrap-datepicker-rails'
 gem 'jquery-rails'
 gem 'jquery-timepicker-rails'
-gem 'turbolinks'
+gem 'turbolinks', '~>2.5.3'
 gem 'twitter-bootstrap-rails-confirm'
 
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,9 +303,8 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     tins (1.13.2)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
+    turbolinks (2.5.3)
+      coffee-rails
     twitter-bootstrap-rails-confirm (1.0.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -377,7 +376,7 @@ DEPENDENCIES
   sprockets (~> 2.11.3)
   sqlite3
   therubyracer
-  turbolinks
+  turbolinks (~> 2.5.3)
   twitter-bootstrap-rails-confirm
   uglifier (~> 2.7.2)
   web-console (~> 2.0)


### PR DESCRIPTION
This is where it was before the latest bundle update.