### PR TITLE
dynamic content - log error, persist derived class

### DIFF
--- a/app/models/dynamic_content.rb
+++ b/app/models/dynamic_content.rb
@@ -171,7 +171,7 @@ class DynamicContent < Content
             end
           end
         else
-          Rails.logger.debug(new_children[index].errors.full_messages)
+          Rails.logger.error(new_children[index].errors.full_messages)
           raise ActiveRecord::Rollback
           return false
         end

--- a/app/models/dynamic_content.rb
+++ b/app/models/dynamic_content.rb
@@ -142,7 +142,7 @@ class DynamicContent < Content
 
         run_callbacks :alter_content do
           @content = content
-          new_children[index].becomes(content.class)
+          new_children[index] = new_children[index].becomes(content.class)
           @new_attributes = content.attributes
         end
 
@@ -171,6 +171,7 @@ class DynamicContent < Content
             end
           end
         else
+          Rails.logger.debug(new_children[index].errors.full_messages)
           raise ActiveRecord::Rollback
           return false
         end


### PR DESCRIPTION
http://apidock.com/rails/ActiveRecord/Persistence/becomes

When loading new content, we were becoming the new class, but not persisting it which was causing problems when assigning attributes specific to the new class (like config). 

Also closes #1409 