### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#Concerto 2 Digital Signage System [![Build Status](https://travis-ci.org/concerto/concerto.png?branch=master)](https://travis-ci.org/concerto/concerto)
+# Concerto 2 Digital Signage System [![Build Status](https://travis-ci.org/concerto/concerto.png?branch=master)](https://travis-ci.org/concerto/concerto)
 
 [![Join the chat at https://gitter.im/concerto/concerto](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/concerto/concerto?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Full Installation Instructions: [https://github.com/concerto/concerto/wiki/Installing-Concerto-2](https://github.com/concerto/concerto/wiki/Installing-Concerto-2)
 
-##What is Concerto?
+## What is Concerto?
 Concerto is an open source digital signage system. Users submit graphic, textual, and other content, and moderators approve that content for use in a variety of content feeds which are displayed on screens connected to computers displaying the Concerto frontned.
 
-##Dependencies
+## Dependencies
 * Ruby 2.0 or newer
 * Rubygems
 * Imagemagick
@@ -21,7 +21,7 @@ Note: For those upgrading Concerto from earlier Debian/Ubuntu versions, make sur
 * Add Concerto repository using ```curl https://get.concerto-signage.org/add_repo.sh | sh```
 * Install Concerto via APT ```sudo apt-get install concerto-full```
     
-##Virtual Server Image (VirtualBox, VMWare, et. al.)
+## Virtual Server Image (VirtualBox, VMWare, et. al.)
 The virtual server image contains a full-stack installation of the Concerto webserver with all components pre-configured.
 
 * Download at [https://dl.concerto-signage.org/concerto_server.ova](https://dl.concerto-signage.org/concerto_server.ova)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
