### PR TITLE
dynamic content refresh exception handling

### DIFF
--- a/app/models/dynamic_content.rb
+++ b/app/models/dynamic_content.rb
@@ -181,6 +181,10 @@ class DynamicContent < Content
     expire_children(old_children)
 
     return true
+
+  rescue Exception => e
+    Rails.logger.error(e.message)
+    return false
   end
 
   # Build all the new child content.


### PR DESCRIPTION
This will allow other content to be refreshed, when the service runs, even if an entry fails.