### PR TITLE
better handle when not connected to internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Full Installation Instructions: [https://github.com/concerto/concerto/wiki/Installing-Concerto-2](https://github.com/concerto/concerto/wiki/Installing-Concerto-2)
 
 ## What is Concerto?
-Concerto is an open source digital signage system. Users submit graphic, textual, and other content, and moderators approve that content for use in a variety of content feeds which are displayed on screens connected to computers displaying the Concerto frontned.
+Concerto is an open source digital signage system. Users submit graphic, textual, and other content, and moderators approve that content for use in a variety of content feeds which are displayed on screens connected to computers displaying the Concerto frontend.
 
 ## Dependencies
 * Ruby 2.0 or newer
@@ -20,13 +20,10 @@ Note: For those upgrading Concerto from earlier Debian/Ubuntu versions, make sur
 
 * Add Concerto repository using ```curl https://get.concerto-signage.org/add_repo.sh | sh```
 * Install Concerto via APT ```sudo apt-get install concerto-full```
-    
+
 ## Virtual Server Image (VirtualBox, VMWare, et. al.)
 The virtual server image contains a full-stack installation of the Concerto webserver with all components pre-configured.
 
 * Download at [https://dl.concerto-signage.org/concerto_server.ova](https://dl.concerto-signage.org/concerto_server.ova)
 
 Concerto 2 is licensed under the Apache License, Version 2.0.
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/concerto/concerto/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/app/models/concerto_plugin.rb
+++ b/app/models/concerto_plugin.rb
@@ -20,12 +20,16 @@ class ConcertoPlugin < ActiveRecord::Base
 
   def self.concerto_addons
     addons = Array.new
-    #we shouldn't be checking github if it's just a script launching rails
-    if !defined?(Rails::Console) && File.split($0).last != 'rake' && Octokit.rate_limit.remaining > 1
-      repositories = Octokit.repos 'concerto-addons'
-      repositories.each do |r|
-        addons << [r.name.titleize, r.name]
+    begin
+      #we shouldn't be checking github if it's just a script launching rails
+      if !defined?(Rails::Console) && File.split($0).last != 'rake' && Octokit.rate_limit.remaining > 1
+        repositories = Octokit.repos 'concerto-addons'
+        repositories.each do |r|
+          addons << [r.name.titleize, r.name]
+        end
       end
+    rescue Faraday::ConnectionFailed => e
+      Rails.logger.error("concerto-addons repos could not be enumerated - #{e.message}")
     end
     return addons
   end

--- a/lib/version_check.rb
+++ b/lib/version_check.rb
@@ -10,7 +10,12 @@ module VersionCheck
         end
       else # Fetch the latest version.
         Rails.logger.info 'Downloading latest Concerto version information for the first time.'
-        version = Octokit.latest_release('concerto/concerto').tag_name
+        begin
+          version = Octokit.latest_release('concerto/concerto').tag_name
+        rescue Faraday::ConnectionFailed => e
+          Rails.logger.error "Unable to fetch Concerto version - #{e.message}"
+          version = nil
+        end
       end
       return version
     rescue Octokit::TooManyRequests => e


### PR DESCRIPTION
These changes will prevent the application from erroring out when connection problems occur due to no internet connectivity.  However, to truly run your site isolated, you'll need to also set the `automatic_bundle_installation` and `airbrake_enabled_initially` settings in the config/concerto.yml to false, and make sure that your settings in the app indicate that you do not want to send errors to the developers.

The background job engine has been tested along with the website, and the concerto player.  

It almost goes without saying that dynamic content sourced from sites outside the isolated network will not be refreshed.

This change supports the scenario where a site (while connected to the internet) wants to bring the system online and install plugins and static content (and perhaps locally sourced dynamic content) and then make their network isolated from the internet.