### PR TITLE
Make Start Date and End Date Required

### DIFF
--- a/app/views/contents/form_elements/_dates.html.erb
+++ b/app/views/contents/form_elements/_dates.html.erb
@@ -20,7 +20,7 @@
               end_time = ConcertoConfig[:content_default_end_time]
             end
           %>
-          <%= form.text_field("start_time[date]", id: "start_time_date", maxlength: 20, class: "datefield input-small", value: start_time_date) %>
+          <%= form.text_field("start_time[date]", id: "start_time_date", maxlength: 20, class: "datefield input-small", value: start_time_date, required: "true") %>
         </div>
         <p>&nbsp;<a class="event-toggleTimeSelects" href="#"><%= t('.set_specific_times') %></a></p>
         <div class="event-timeSelectDiv">
@@ -38,7 +38,7 @@
       <div class="input">
         <div class="input-prepend cursor-pointer" style="margin-bottom: 6px;">
           <span class="add-on"><i class="fa fa-calendar"></i></span>
-          <%= form.text_field("end_time[date]", id: "end_time_date", maxlength: 20, class: "datefield input-small", value: end_time_date) %>
+          <%= form.text_field("end_time[date]", id: "end_time_date", maxlength: 20, class: "datefield input-small", value: end_time_date, required: "true") %>
         </div>
         <div class="event-timeSelectDiv">
           <div class="input-prepend">


### PR DESCRIPTION
If a piece of content is submitted without a start date or end date, screens subscribed to those feeds will throw 500 errors and not display _any_ content. Making these fields `required` with html5 makes the users not able to submit content with blank dates.