### PR TITLE
revert - dont double sanitize htmltext

### DIFF
--- a/app/models/text_content.rb
+++ b/app/models/text_content.rb
@@ -1,6 +1,4 @@
 class TextContent < Content
-  before_save :process_markdown
-
   # Validations
   validates :duration, numericality: { greater_than: 0 }
   validates :data, presence: true

--- a/app/models/ticker.rb
+++ b/app/models/ticker.rb
@@ -1,6 +1,6 @@
 class Ticker < TextContent
   after_initialize :set_kind
-  before_save :alter_type
+  before_save :process_markdown, :alter_type
 
   # Automatically set the kind for the content
   # if it is new.


### PR DESCRIPTION
This fixes #1466.  The bug was introduced back in March 6, 2017 when I DRYed up some code and extracted some common features in two classes into a new ancestor class, and accidentally included sanitizing the htmltext content where it wasn't happening before. (The simple-rss build_content already sanitizes it.)