### PR TITLE
Solve SMTP server connection when credentials used

### DIFF
--- a/config/initializers/16-mailer.rb
+++ b/config/initializers/16-mailer.rb
@@ -13,8 +13,8 @@ if ActiveRecord::Base.connection.table_exists? 'concerto_configs'
     }
     ActionMailer::Base.smtp_settings[:openssl_verify_mode] = 'none' if ConcertoConfig[:openssl_verify_mode_none] == true
     if !ConcertoConfig[:smtp_username].blank?
-      ActionMailer::Base.smtp_settings[:authentication] = ConcertoConfig[:smtp_auth_type],
-      ActionMailer::Base.smtp_settings[:user_name] = ConcertoConfig[:smtp_username],
+      ActionMailer::Base.smtp_settings[:authentication] = ConcertoConfig[:smtp_auth_type]
+      ActionMailer::Base.smtp_settings[:user_name] = ConcertoConfig[:smtp_username]
       ActionMailer::Base.smtp_settings[:password] = ConcertoConfig[:smtp_password]
     end
   end


### PR DESCRIPTION
ActionMailer user_name and password where being added into the Authentication key as an array (due to the additional commas). 
SMTP auth now working