### PR TITLE
Gem version changes for Ruby 2.5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'rmagick', require: 'rmagick', platforms: :ruby
 gem 'attachable'
 
 gem 'cancancan'
-gem 'devise', '~> 3.5.5'
+gem 'devise', :git=> "https://github.com/plataformatec/devise.git", :branch => "3-stable"
 
 gem 'json'
 gem 'rubyzip', '~> 1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     debug_inspector (0.0.3)
     declarative (0.0.9)
     declarative-option (0.1.0)
-    delayed_job (4.1.3)
+    delayed_job (>=4.1.3, <4.1.5)
       activesupport (>= 3.0, < 5.2)
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)


### PR DESCRIPTION
To have Concerto run on Ruby 2.5.x, these minor changes to devise and delayed_job are needed.  See https://github.com/concerto/concerto/issues/1496