### PR TITLE
Rails 4 is incompatible with the 1.0 version of the pg gem, so add a …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'kaminari'
 gem 'sqlite3', '~> 1.3.6', group: [:development, :test]
 
 gem 'mysql2', group: :mysql
-gem 'pg', group: :postgres
+gem 'pg', '~> 0.18', group: :postgres
 
 gem 'public_activity'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     os (0.9.6)
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    pg (1.1.4)
+    pg (0.21.0)
     public_activity (1.6.4)
       actionpack (>= 3.0.0)
       activerecord (>= 3.0)
@@ -383,7 +383,7 @@ DEPENDENCIES
   mysql2
   nprogress-rails (~> 0.2.0.2)
   octokit (~> 4.2.0)
-  pg
+  pg (~> 0.18)
   public_activity
   rack-mini-profiler
   rails (~> 4.2)


### PR DESCRIPTION
…version to the Gemfile to stick with the 0.X versions that work

It looks like PostgreSQL and Rails dont get along again until Rails 5.1.5
https://github.com/rails/rails/issues/31673

Horray, somebody is maintaining the Concerto upstream again!