### PR TITLE
Sanitize keys before confirmation modal.

### DIFF
--- a/app/views/concerto_plugins/show.html.erb
+++ b/app/views/concerto_plugins/show.html.erb
@@ -10,7 +10,7 @@
           <%= link_to t(:edit_model, model: ConcertoPlugin.model_name.human), edit_concerto_plugin_path(@concerto_plugin), class: "btn" %>
         <% end %>
         <% if can? :delete, @concerto_plugin %>
-          <%= link_to t(:destroy_model, model: ConcertoPlugin.model_name.human), @concerto_plugin, data: { confirm: t(:are_you_sure_delete_model_key, model: ConcertoPlugin.model_name.human, key: @concerto_plugin.gem_name) }, method: :delete, class: "btn" %>
+          <%= link_to t(:destroy_model, model: ConcertoPlugin.model_name.human), @concerto_plugin, data: { confirm: t(:are_you_sure_delete_model_key, model: ConcertoPlugin.model_name.human, key: sanitize(@concerto_plugin.gem_name)) }, method: :delete, class: "btn" %>
         <% end %>
       </div>
     </div>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -21,7 +21,7 @@
               <%= link_to t(:edit_model, model: Content.model_name.human), edit_content_path(@content), class: "btn" %>
             <% end %>
             <% if can? :delete, @content %>
-              <%= link_to t(:destroy_model, model: Content.model_name.human), @content, data: { confirm: t(:are_you_sure_delete_model_key, model: Content.model_name.human, key: @content.name) }, method: :delete, class: "btn" %>
+              <%= link_to t(:destroy_model, model: Content.model_name.human), @content, data: { confirm: t(:are_you_sure_delete_model_key, model: Content.model_name.human, key: sanitize(@content.name)) }, method: :delete, class: "btn" %>
             <% end %>
           </div>
         </div>

--- a/app/views/field_configs/index.html.erb
+++ b/app/views/field_configs/index.html.erb
@@ -39,7 +39,7 @@
               <%= link_to t(:edit, model: FieldConfig.model_name.human), edit_screen_field_field_config_path(@screen, @field, field_config), class: "btn" %>
             <% end %>
             <% if can? :delete, field_config %>
-              <%= link_to t(:destroy, model: FieldConfig.model_name.human), [@screen, @field, field_config], method: :delete, data: { confirm: t(:are_you_sure_delete_model_key, model: FieldConfig.model_name.human, key: field_config.key) }, class: "btn" %>
+              <%= link_to t(:destroy, model: FieldConfig.model_name.human), [@screen, @field, field_config], method: :delete, data: { confirm: t(:are_you_sure_delete_model_key, model: FieldConfig.model_name.human, key: sanitize(field_config.key)) }, class: "btn" %>
             <% end %>
           </td>
         </tr>

--- a/app/views/fields/edit.html.erb
+++ b/app/views/fields/edit.html.erb
@@ -3,7 +3,7 @@
    <div class="viewblock-header_right">
       <div class="button-padding">
         <% if can? :delete, @field %>
-          <%= link_to t(:destroy_model, model: Field.model_name.human), @field, data: { confirm: t(:are_you_sure_delete_model_key, model: Field.model_name.human, key: @field.name) }, method: :delete, class: "btn" %>
+          <%= link_to t(:destroy_model, model: Field.model_name.human), @field, data: { confirm: t(:are_you_sure_delete_model_key, model: Field.model_name.human, key: sanitize(@field.name)) }, method: :delete, class: "btn" %>
         <% end %>
       </div>
     </div>

--- a/app/views/groups/_show_header.html.erb
+++ b/app/views/groups/_show_header.html.erb
@@ -14,7 +14,7 @@
     <% if can? :delete, @group %>
       <% if @group.is_deletable? %>
         <%= link_to t(:destroy_model, model: Group.model_name.human), @group,
-          data: { confirm: t(:are_you_sure_delete_model_key, model:Group.model_name.human, key: @group.name) }, method: :delete, class: "btn" %>
+          data: { confirm: t(:are_you_sure_delete_model_key, model:Group.model_name.human, key: sanitize(@group.name)) }, method: :delete, class: "btn" %>
       <% else %>
         <%= link_to t(:destroy_model, model: Group.model_name.human), '#', class: "btn disabled tooltip-basic", 'data-tooltip-text' => t(:group_not_deletable, model: Group.model_name.human, key: @group.name) %>
       <% end %>

--- a/app/views/groups/manage_members.html.erb
+++ b/app/views/groups/manage_members.html.erb
@@ -34,7 +34,7 @@
             <th style="width: 25%;"> <%= t('.permissions.all') %> </th>
             <th style="width: 25%;">
               <% if can? :update, leader %>
-                <%= link_to t('.demote_to_regular'), group_membership_path(@group, leader, perform: "demote"), method: :put, class: "btn btn-small btn-danger", data: { confirm: t(:are_you_sure_demote_user, user: leader.user.name) } %>
+                <%= link_to t('.demote_to_regular'), group_membership_path(@group, leader, perform: "demote"), method: :put, class: "btn btn-small btn-danger", data: { confirm: t(:are_you_sure_demote_user, user: sanitize(leader.user.name)) } %>
               <% end %>
             </th>
           </tr>
@@ -63,7 +63,7 @@
                   <td>
                     <% if can? :update, m.object %>
                       <%= link_to t('.promote_to_leader'), group_membership_path(@group, m.object, perform: "promote"), method: :put, class: "btn btn-small btn-success" %>
-                      <%= link_to t('.remove_from_group'), group_membership_path(@group , m.object), method: :delete, class: "btn btn-small btn-danger", data: { confirm: t(:are_you_sure_remove_user_group, user: m.object.user.name, group: @group.name) } %>
+                      <%= link_to t('.remove_from_group'), group_membership_path(@group , m.object), method: :delete, class: "btn btn-small btn-danger", data: { confirm: t(:are_you_sure_remove_user_group, user: sanitize(m.object.user.name), group: sanitize(@group.name)) } %>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/kinds/index.html.erb
+++ b/app/views/kinds/index.html.erb
@@ -12,7 +12,7 @@
       <% @kinds.each do |kind| %>
           <tr>
             <td><%= kind.name %></td>
-            <td><%= link_to t(:show), kind %> <%= link_to t(:edit), edit_kind_path(kind) %> <%= link_to t(:destroy), kind, data: {confirm: t(:are_you_sure_delete_model_key, model: Kind.model_name.human, key: kind.name)}, method: :delete %></td>
+            <td><%= link_to t(:show), kind %> <%= link_to t(:edit), edit_kind_path(kind) %> <%= link_to t(:destroy), kind, data: {confirm: t(:are_you_sure_delete_model_key, model: Kind.model_name.human, key: sanitize(kind.name))}, method: :delete %></td>
           </tr>
       <% end %>
     </table>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -31,7 +31,7 @@
             <% end %>
             <% if can? :delete, page %>
 
-                <%= link_to t(:destroy, model: Page), page, data: { confirm: t(:are_you_sure_delete_model_key, model:Page.model_name.human, key: page.title) }, method: :delete, class: "btn" %>
+                <%= link_to t(:destroy, model: Page), page, data: { confirm: t(:are_you_sure_delete_model_key, model:Page.model_name.human, key: sanitize(page.title)) }, method: :delete, class: "btn" %>
 
             <% end %>
           </td>

--- a/app/views/screens/_show_header.html.erb
+++ b/app/views/screens/_show_header.html.erb
@@ -4,7 +4,7 @@
       <%= link_to t(:edit_model, model: Screen.model_name.human), edit_screen_path(@screen), class: "btn" %>
     <% end %>
     <% if can? :delete, @screen %>
-      <%= link_to t(:destroy_model, model: Screen.model_name.human), @screen, data: { confirm: t(:are_you_sure_delete_model_key, model: Screen.model_name.human, key: @screen.name) }, method: :delete, class: "btn" %>
+      <%= link_to t(:destroy_model, model: Screen.model_name.human), @screen, data: { confirm: t(:are_you_sure_delete_model_key, model: Screen.model_name.human, key: sanitize(@screen.name)) }, method: :delete, class: "btn" %>
     <% end %>
   </div>
 </div>

--- a/app/views/submissions/_index_header.html.erb
+++ b/app/views/submissions/_index_header.html.erb
@@ -4,7 +4,7 @@
       <%= link_to t('.edit_feed'), edit_feed_path(@feed), class: "btn" %>
     <% end %>
     <% if can? :delete, @feed %>
-      <%= link_to t('.delete_feed'), @feed, data: { confirm: t(:are_you_sure_delete_model_key, model: Feed.model_name.human, key: @feed.name) }, method: :delete, class: "btn" %>
+      <%= link_to t('.delete_feed'), @feed, data: { confirm: t(:are_you_sure_delete_model_key, model: Feed.model_name.human, key: sanitize(@feed.name)) }, method: :delete, class: "btn" %>
     <% end %>
   </div>
 </div>

--- a/app/views/submissions/_show_header.html.erb
+++ b/app/views/submissions/_show_header.html.erb
@@ -4,7 +4,7 @@
       <%= link_to t(:edit_model, model: Content.model_name.human), edit_content_path(@submission.content), class: "btn" %>
     <% end %>
     <% if can? :delete, @submission.content %>
-      <%= link_to t(:destroy_model, model: Content.model_name.human), @submission.content, data: { confirm: t(:are_you_sure_delete_model_key, model: Content.model_name.human, key: @submission.content.name) }, method: :delete, class: "btn" %>
+      <%= link_to t(:destroy_model, model: Content.model_name.human), @submission.content, data: { confirm: t(:are_you_sure_delete_model_key, model: Content.model_name.human, key: sanitize(@submission.content.name)) }, method: :delete, class: "btn" %>
     <% end %>
   </div>
 </div>

--- a/app/views/templates/_show_header.html.erb
+++ b/app/views/templates/_show_header.html.erb
@@ -4,7 +4,7 @@
 
     <% if can? :delete, @template %>
       <% if @template.is_deletable? %>
-        <%= link_to t('.delete_template'), @template, data: { confirm: t(:are_you_sure_delete_model_key, model: ::Template.model_name.human, key: @template.name) }, method: :delete, class: "btn"  %>
+        <%= link_to t('.delete_template'), @template, data: { confirm: t(:are_you_sure_delete_model_key, model: ::Template.model_name.human, key: sanitize(@template.name)) }, method: :delete, class: "btn"  %>
       <% else %>
         <%= link_to t('.delete_template'), '#', class: "btn disabled tooltip-basic", 'data-tooltip-text' => t(:cannot_delete_template, screens: @template.screen_dependencies.collect { |s| s.name if can? :read, s}.join(", ")) %>
       <% end %>

--- a/app/views/users/_show_header.html.erb
+++ b/app/views/users/_show_header.html.erb
@@ -3,7 +3,7 @@
     <% if can? :edit, @user %>
       <%= link_to t(:edit_model, model: User.model_name.human), edit_user_path, class: "btn" %>
       <%= link_to t('users.change_password'), edit_user_registration_path, class: "btn" if current_user == @user %>
-      <%= link_to t(:destroy_model, model: User.model_name.human), user_path(@user), data: { confirm: t(:are_you_sure_delete_model_key, model: User.model_name.human, key: @user.name)}, method: :delete, class: "btn" if current_user != @user %>
+      <%= link_to t(:destroy_model, model: User.model_name.human), user_path(@user), data: { confirm: t(:are_you_sure_delete_model_key, model: User.model_name.human, key: sanitize(@user.name))}, method: :delete, class: "btn" if current_user != @user %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -61,7 +61,7 @@
             <% if can? :delete, user %>
               <% if user.is_deletable? %>
                 <%= link_to t(:destroy, model: User.model_name.human), user,
-                            data: { confirm: t(:are_you_sure_delete_model_key, model: User.model_name.human, key: user.name) }, method: :delete, class: "btn" %>
+                            data: { confirm: t(:are_you_sure_delete_model_key, model: User.model_name.human, key: sanitize(user.name)) }, method: :delete, class: "btn" %>
               <% else %>
                 <%= link_to t(:destroy, model: User.model_name.human), '#', class: "btn disabled tooltip-basic", 'data-tooltip-text' => t(:user_not_deletable, model: User.model_name.human, key: user.name) %>
               <% end %>


### PR DESCRIPTION
Without sanitization, these are susceptible to an varying degrees of XSS attack depending on the input.  When the values are displayed in the twitter-bootstrap-confirmation modal (I don't fully understand how it works) the JS is rendered and executed. The `user.name` fields are the most concerning for instances that allow public registration, but we sanitize everywhere this pattern is used to be safe.

Kudos to Ben Shaw (@sudonoodle) for finding this vulnerability!