### PR TITLE
use ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
-  - 2.5.5
+  - 2.6
 
 env:
   - DB=sqlite


### PR DESCRIPTION
@bamnet I checked, the fronted and the screen look fine. Is there a reason we didn't support 2.6 before?