### PR TITLE
Ruby 2.6.10 doesn't support date 3.3.4...use 2.0.3 instead

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       rails
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    date (3.3.4)
+    date (2.0.3)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     delayed_job (4.1.11)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     image: mysql
     # utf8mb4 https://stackoverflow.com/a/53398381/1778068
-    command: --authentication-policy=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: concerto


### PR DESCRIPTION
Concerto is currently using Ruby 2.6.10.  I tried setting it up under Docker to replace the VM-based installation my employer uses, but I got this error when I tried running it:

```/usr/local/rvm/rubies/ruby-2.6.10/lib/ruby/2.6.0/bundler/spec_set.rb:91:in `block in materialize': Could not find date-3.3.4 in any of the sources (Bundler::GemNotFound)```

According to https://stdgems.org/date/, date 3.3.4 needs Ruby 3.3.0 or later.  The version of date that is compatible with Ruby 2.6.10 is 2.0.3.  I edited Gemfile.lock, ran ```docker build -t concerto . && docker compose up``` again, and this time it came up with the "register first admin account" screen when I loaded it in my browser.

Also, ```--authentication-policy=mysql_native_password``` needs to be removed from docker-compose.yml, or else the database container won't start up and Concerto won't run.