### PR TITLE
Track screen online/offline status

### DIFF
--- a/app/controllers/frontend/content_controller.rb
+++ b/app/controllers/frontend/content_controller.rb
@@ -8,6 +8,8 @@ class Frontend::ContentController < Frontend::ApplicationController
 
     logger.debug "Found #{@content.count} content to render in #{@screen.name}'s #{@field.name} field"
 
+    @screen.touch(:last_seen_at)
+
     response.headers["X-Config-Version"] = @screen.config_version
 
     render json: @content

--- a/app/controllers/frontend/screens_controller.rb
+++ b/app/controllers/frontend/screens_controller.rb
@@ -14,6 +14,8 @@ class Frontend::ScreensController < Frontend::ApplicationController
       }
     }
 
+    @screen.touch(:last_seen_at)
+
     response.headers["X-Config-Version"] = @screen.config_version
 
     render json: {

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -23,6 +23,12 @@ class Screen < ApplicationRecord
 
   validates :name, presence: true
 
+  ONLINE_THRESHOLD = 5.minutes
+
+  def online?
+    last_seen_at.present? && last_seen_at > ONLINE_THRESHOLD.ago
+  end
+
   # Returns an MD5 hash of the most recent configuration change timestamp.
   # This is used by the frontend to detect when the screen configuration has changed
   # and trigger a reload.

--- a/app/views/screens/index.html.erb
+++ b/app/views/screens/index.html.erb
@@ -28,11 +28,16 @@
           
           <div class="space-y-2 text-caption text-neutral-500">
             <div class="flex items-center justify-center">
-              <%= heroicon('check-circle', class: 'w-4 h-4 mr-1') %>
-              <span class="text-success">Online</span>
+              <% if screen.online? %>
+                <%= heroicon('check-circle', class: 'w-4 h-4 mr-1') %>
+                <span class="text-success">Online</span>
+              <% else %>
+                <%= heroicon('x-circle', class: 'w-4 h-4 mr-1') %>
+                <span class="text-neutral-500">Offline</span>
+              <% end %>
             </div>
-            
-            <div>Last seen <%= time_ago_in_words(screen.updated_at) %> ago</div>
+
+            <div>Last seen <%= screen.last_seen_at ? "#{time_ago_in_words(screen.last_seen_at)} ago" : "Never" %></div>
           </div>
         </div>
       </div>

--- a/db/migrate/20260203035147_add_last_seen_at_to_screens.rb
+++ b/db/migrate/20260203035147_add_last_seen_at_to_screens.rb
@@ -1,0 +1,5 @@
+class AddLastSeenAtToScreens < ActiveRecord::Migration[8.1]
+  def change
+    add_column :screens, :last_seen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_29_154504) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_03_035147) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -120,6 +120,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_29_154504) do
   create_table "screens", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "group_id", null: false
+    t.datetime "last_seen_at"
     t.string "name"
     t.integer "template_id", null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/frontend/screens_controller_test.rb
+++ b/test/controllers/frontend/screens_controller_test.rb
@@ -26,6 +26,16 @@ class Frontend::ScreensControllerTest < ActionDispatch::IntegrationTest
     assert_match(/^[a-f0-9]{32}$/, config_version)
   end
 
+  test "should update last_seen_at" do
+    assert_nil @screen.last_seen_at
+
+    get frontend_screen_url(id: @screen.id, format: :json)
+    assert_response :success
+
+    @screen.reload
+    assert_not_nil @screen.last_seen_at
+  end
+
   test "should handle template without attached image" do
     # Create a screen with a template that has no image attached
     template_without_image = Template.create!(name: "Template Without Image")

--- a/test/models/screen_test.rb
+++ b/test/models/screen_test.rb
@@ -1,6 +1,24 @@
 require "test_helper"
 
 class ScreenTest < ActiveSupport::TestCase
+  test "online? returns true when last_seen_at is recent" do
+    screen = screens(:one)
+    screen.update_column(:last_seen_at, 1.minute.ago)
+    assert screen.online?
+  end
+
+  test "online? returns false when last_seen_at is old" do
+    screen = screens(:one)
+    screen.update_column(:last_seen_at, 10.minutes.ago)
+    assert_not screen.online?
+  end
+
+  test "online? returns false when last_seen_at is nil" do
+    screen = screens(:one)
+    screen.update_column(:last_seen_at, nil)
+    assert_not screen.online?
+  end
+
   test "config_version returns MD5 hash string" do
     screen = screens(:one)
     version = screen.config_version


### PR DESCRIPTION
## Summary
- Add `last_seen_at` timestamp to screens, updated on every frontend player request (screen config and content fetches)
- Add `Screen#online?` helper using a 5-minute threshold
- Show online/offline status and actual last seen time in the admin screens index

Closes #1611

## Test plan
- [ ] Verify `bin/rails test test/models/screen_test.rb` passes (online? method tests)
- [ ] Verify `bin/rails test test/controllers/frontend/screens_controller_test.rb` passes (heartbeat update test)
- [ ] Load a screen in the frontend player and confirm `last_seen_at` updates
- [ ] Check admin screens index shows "Online" for active screens and "Offline"/"Never" for inactive ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)