### PR TITLE
Fix Claude Code Review action to post PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -36,6 +36,8 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*),Bash(sed:*),Bash(awk:*),Bash(test:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- Fixes the Claude Code Review GitHub Action which stopped posting comments on PRs
- Changes `pull-requests` permission from `read` to `write`
- Adds `--allowedTools` flag with required tools for commenting

## Root Cause

The action was failing with "This command requires approval" errors because:
1. Missing write permission on pull-requests
2. No `--allowedTools` configuration to permit `gh` CLI and MCP comment tools

## Tools Added

- `mcp__github_inline_comment__create_inline_comment` - inline code annotations
- `Bash(gh pr comment/diff/view/list/review:*)` - PR operations
- `Bash(gh issue view/list:*)` - issue operations  
- `Bash(gh search:*)` - search operations
- `Bash(sed/awk/test:*)` - text processing utilities

## Test plan

- [ ] Merge this PR
- [ ] Open a new PR and verify the code review action posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)