### PR TITLE
Run solid queue in puma by default in prod.

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -13,4 +13,7 @@ export PORT="${PORT:-3000}"
 export RUBY_DEBUG_OPEN="true"
 export RUBY_DEBUG_LAZY="true"
 
+# Disable Solid Queue job in development, since jobs run immediately.
+export SOLID_QUEUE_IN_PUMA="false"
+
 exec foreman start -f Procfile.dev "$@"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,7 +35,9 @@ port ENV.fetch("PORT", 3000)
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+# In multi-server deployments, this should be disabled and the Solid Queue
+# supervisor should be run separately.
+plugin :solid_queue unless ENV["SOLID_QUEUE_IN_PUMA"] == "false"
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.


### PR DESCRIPTION
Run Solid Queue in puma by default.

This can be disabled by setting SOLID_QUEUE_IN_PUMA to false, which is set in bin/dev so local development does not try to start a solid queue supervisor.  In dev, the queue is stored in-memory and jobs are processed ~immediately so there is nothing to supervise.

Closes #1685.