### PR TITLE
Fix template position borders floating around content

### DIFF
--- a/app/frontend/components/ConcertoField.vue
+++ b/app/frontend/components/ConcertoField.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { onMounted, onBeforeUnmount, ref, shallowRef } from 'vue'
+import { computed, onMounted, onBeforeUnmount, ref, shallowRef } from 'vue'
 
 import ConcertoGraphic, { preload as preloadGraphic } from './ConcertoGraphic.vue';
 import ConcertoRichText from './ConcertoRichText.vue';
 import ConcertoVideo from './ConcertoVideo.vue';
 import ConcertoClock from './ConcertoClock.vue';
 import { useConfigVersion } from '../composables/useConfigVersion.js';
+import { splitFieldStyle } from '../utils/splitFieldStyle.js';
 
 // Content is shown for 10 seconds if it does not have it's own duration.
 const defaultDuration = 10;
@@ -56,6 +57,8 @@ const props = defineProps({
    */
   fieldStyle: {type: String, required: false, default: ''},
 });
+
+const parsedStyles = computed(() => splitFieldStyle(props.fieldStyle));
 
 const currentContent = shallowRef(null);
 const currentContentConfig = ref({});
@@ -190,13 +193,14 @@ onBeforeUnmount(() => {
   <div
     class="field"
     :class="{ 'dev-border': isDevelopment }"
-    :style="fieldStyle"
+    :style="parsedStyles.textStyle"
   >
     <Transition>
       <component
         :is="currentContent"
         :key="currentContentConfig.id"
         :content="currentContentConfig"
+        :box-style="parsedStyles.boxStyle"
         @click="next"
         @take-over-timer="delegateTimerToContent"
         @next="next"

--- a/app/frontend/components/ConcertoGraphic.vue
+++ b/app/frontend/components/ConcertoGraphic.vue
@@ -1,18 +1,18 @@
 <script setup>
-import { computed } from 'vue';
-
-const props = defineProps({
-  content: {type: Object, required: true}
+defineProps({
+  content: {type: Object, required: true},
+  boxStyle: {type: String, required: false, default: ''},
 });
-
-const backgroundImageUrl = computed(() => {
-  return `url(${props.content.image})`;
-})
-
 </script>
 
 <template>
-  <div class="graphic" />
+  <div class="graphic-container">
+    <img
+      class="graphic"
+      :src="content.image"
+      :style="boxStyle"
+    >
+  </div>
 </template>
 
 <script>
@@ -68,17 +68,18 @@ export function preload(content) {
 </script>
 
 <style scoped>
+  .graphic-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+
   .graphic {
     display: block;
-    position: absolute;
-    margin: auto;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-image: v-bind('backgroundImageUrl');
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
   }
 </style>

--- a/app/frontend/components/ConcertoTiktokVideo.vue
+++ b/app/frontend/components/ConcertoTiktokVideo.vue
@@ -3,7 +3,8 @@ import { computed, onMounted, onBeforeUnmount, ref } from 'vue';
 import { useVideoWatchdog } from '../composables/useVideoWatchdog.js';
 
 const props = defineProps({
-  content: { type: Object, required: true }
+  content: { type: Object, required: true },
+  boxStyle: { type: String, required: false, default: '' },
 });
 
 const emit = defineEmits(['takeOverTimer', 'next']);
@@ -90,6 +91,7 @@ onBeforeUnmount(() => {
     frameborder="0"
     allow="autoplay; encrypted-media"
     :src="videoUrl"
+    :style="boxStyle"
   />
 </template>
 

--- a/app/frontend/components/ConcertoVideo.vue
+++ b/app/frontend/components/ConcertoVideo.vue
@@ -5,7 +5,8 @@ import ConcertoVimeoVideo from './ConcertoVimeoVideo.vue';
 import ConcertoTiktokVideo from './ConcertoTiktokVideo.vue';
 
 const props = defineProps({
-  content: { type: Object, required: true }
+  content: { type: Object, required: true },
+  boxStyle: { type: String, required: false, default: '' },
 });
 
 const videoSource = computed(() => {
@@ -18,14 +19,17 @@ const videoSource = computed(() => {
   <ConcertoYoutubeVideo
     v-if="videoSource === 'youtube'"
     :content="content"
+    :box-style="boxStyle"
   />
   <ConcertoVimeoVideo
     v-else-if="videoSource === 'vimeo'"
     :content="content"
+    :box-style="boxStyle"
   />
   <ConcertoTiktokVideo
     v-else-if="videoSource === 'tiktok'"
     :content="content"
+    :box-style="boxStyle"
   />
   <div v-else>
     Unsupported video source

--- a/app/frontend/components/ConcertoVimeoVideo.vue
+++ b/app/frontend/components/ConcertoVimeoVideo.vue
@@ -6,7 +6,8 @@ const VIMEO_API_URL = 'https://player.vimeo.com/api/player.js';
 const API_LOAD_TIMEOUT_MS = 30000; // 30 seconds
 
 const props = defineProps({
-  content: { type: Object, required: true }
+  content: { type: Object, required: true },
+  boxStyle: { type: String, required: false, default: '' },
 });
 
 const emit = defineEmits(['takeOverTimer', 'next']);
@@ -114,6 +115,7 @@ onBeforeUnmount(() => {
     frameborder="0"
     allow="autoplay"
     :src="videoUrl"
+    :style="boxStyle"
   />
 </template>
 

--- a/app/frontend/components/ConcertoYoutubeVideo.vue
+++ b/app/frontend/components/ConcertoYoutubeVideo.vue
@@ -7,7 +7,8 @@ const API_LOAD_TIMEOUT_MS = 30000; // 30 seconds
 const TIME_CHECK_INTERVAL_MS = 5000;
 
 const props = defineProps({
-  content: { type: Object, required: true }
+  content: { type: Object, required: true },
+  boxStyle: { type: String, required: false, default: '' },
 });
 
 const hasDuration = computed(() => {
@@ -146,6 +147,7 @@ onBeforeUnmount(() => {
     frameborder="0"
     allow="autoplay"
     :src="videoUrl"
+    :style="boxStyle"
   />
 </template>
 

--- a/app/frontend/utils/splitFieldStyle.js
+++ b/app/frontend/utils/splitFieldStyle.js
@@ -1,0 +1,46 @@
+const boxModelPrefixes = [
+  'border',
+  'padding',
+  'box-shadow',
+  'outline',
+];
+
+/**
+ * Splits a CSS style string into inheritable text styles and box-model styles.
+ *
+ * Field styles (color, font-family, background, etc.) stay on the outer field
+ * container. Box-model styles (border, padding, etc.) are passed to content
+ * components that can apply them to the appropriate element.
+ *
+ * @param {string} styleString - Raw CSS style string, e.g. "color:#000; border:1px solid #ccc;"
+ * @returns {{ textStyle: string, boxStyle: string }}
+ */
+export function splitFieldStyle(styleString) {
+  if (!styleString) {
+    return { textStyle: '', boxStyle: '' };
+  }
+
+  const textParts = [];
+  const boxParts = [];
+
+  for (const segment of styleString.split(';')) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex === -1) continue;
+
+    const property = trimmed.substring(0, colonIndex).trim().toLowerCase();
+
+    if (boxModelPrefixes.some(prefix => property.startsWith(prefix))) {
+      boxParts.push(trimmed);
+    } else {
+      textParts.push(trimmed);
+    }
+  }
+
+  return {
+    textStyle: textParts.length ? textParts.join('; ') + ';' : '',
+    boxStyle: boxParts.length ? boxParts.join('; ') + ';' : '',
+  };
+}

--- a/test/frontend/components/ConcertoField.test.js
+++ b/test/frontend/components/ConcertoField.test.js
@@ -90,7 +90,7 @@ describe('ConcertoField', () => {
 
     await flushPromises();
 
-    expect(wrapper.findComponent(ConcertoGraphic).props()).toEqual(
+    expect(wrapper.findComponent(ConcertoGraphic).props()).toMatchObject(
       {
         content: fieldContent[0]
       }
@@ -143,7 +143,7 @@ describe('ConcertoField', () => {
     await flushPromises();
 
     // First load displays the initial graphic.
-    expect(wrapper.findComponent(ConcertoGraphic).props()).toEqual(
+    expect(wrapper.findComponent(ConcertoGraphic).props()).toMatchObject(
       {
         content: fieldUnknownContent[0]
       }
@@ -156,7 +156,7 @@ describe('ConcertoField', () => {
     await nextTick();
 
     // Skips over the unknown content type and renders the graphic.
-    expect(wrapper.findComponent(ConcertoGraphic).props()).toEqual(
+    expect(wrapper.findComponent(ConcertoGraphic).props()).toMatchObject(
       {
         content: fieldUnknownContent[2]
       }
@@ -192,6 +192,82 @@ describe('ConcertoField', () => {
     wrapper.findComponent(ConcertoGraphic).vm.$emit('next');
     await nextTick();
     expect(wrapper.findComponent(ConcertoRichText).exists()).toBe(true);
+  });
+
+  describe('style splitting', () => {
+    it('applies text styles to .field and box styles to content component', async () => {
+      const wrapper = mount(ConcertoField, {
+        props: {
+          apiUrl: fieldContentUrl,
+          fieldStyle: 'color:#000; border:1px solid #ccc; font-family:Arial;',
+        },
+        global: { stubs: { transition: false } },
+      });
+
+      await flushPromises();
+
+      const fieldStyle = wrapper.get('.field').attributes('style');
+      expect(fieldStyle).toContain('font-family: Arial');
+      expect(fieldStyle).not.toContain('border');
+
+      const graphic = wrapper.findComponent(ConcertoGraphic);
+      expect(graphic.props('boxStyle')).toBe('border:1px solid #ccc;');
+    });
+
+    it('passes empty boxStyle when only text styles present', async () => {
+      const wrapper = mount(ConcertoField, {
+        props: {
+          apiUrl: fieldContentUrl,
+          fieldStyle: 'font-weight:bold;',
+        },
+        global: { stubs: { transition: false } },
+      });
+
+      await flushPromises();
+
+      const fieldStyle = wrapper.get('.field').attributes('style');
+      expect(fieldStyle).toContain('font-weight');
+
+      const graphic = wrapper.findComponent(ConcertoGraphic);
+      expect(graphic.props('boxStyle')).toBe('');
+    });
+
+    it('passes empty boxStyle and no field style when fieldStyle is empty', async () => {
+      const wrapper = mount(ConcertoField, {
+        props: {
+          apiUrl: fieldContentUrl,
+          fieldStyle: '',
+        },
+        global: { stubs: { transition: false } },
+      });
+
+      await flushPromises();
+
+      const fieldStyle = wrapper.get('.field').attributes('style') || '';
+      expect(fieldStyle).toBe('');
+
+      const graphic = wrapper.findComponent(ConcertoGraphic);
+      expect(graphic.props('boxStyle')).toBe('');
+    });
+
+    it('passes box styles to content when no text styles', async () => {
+      const wrapper = mount(ConcertoField, {
+        props: {
+          apiUrl: fieldContentUrl,
+          fieldStyle: 'border:solid 2px #663333;',
+        },
+        global: { stubs: { transition: false } },
+      });
+
+      await flushPromises();
+
+      const fieldStyle = wrapper.get('.field').attributes('style') || '';
+      expect(fieldStyle).not.toContain('border');
+
+      const graphic = wrapper.findComponent(ConcertoGraphic);
+      expect(graphic.props('boxStyle')).toBe('border:solid 2px #663333;');
+    });
+
   });
 
   describe('preloading', () => {

--- a/test/frontend/components/ConcertoGraphic.test.js
+++ b/test/frontend/components/ConcertoGraphic.test.js
@@ -10,9 +10,10 @@ describe('ConcertoGraphic', () => {
     };
     const wrapper = mount(ConcertoGraphic, { props: { content: content }});
 
-    const style = wrapper.get('.graphic').element.style;
+    const img = wrapper.get('.graphic');
 
-    expect(style.cssText).toContain('url(image.jpg)');
+    expect(img.element.tagName).toBe('IMG');
+    expect(img.attributes('src')).toBe('image.jpg');
   })
 })
 

--- a/test/frontend/utils/splitFieldStyle.test.js
+++ b/test/frontend/utils/splitFieldStyle.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { splitFieldStyle } from '~/utils/splitFieldStyle.js'
+
+describe('splitFieldStyle', () => {
+  describe('edge cases', () => {
+    it('returns empty strings for empty input', () => {
+      expect(splitFieldStyle('')).toEqual({ textStyle: '', boxStyle: '' });
+    });
+
+    it('returns empty strings for undefined input', () => {
+      expect(splitFieldStyle(undefined)).toEqual({ textStyle: '', boxStyle: '' });
+    });
+
+    it('returns empty strings for null input', () => {
+      expect(splitFieldStyle(null)).toEqual({ textStyle: '', boxStyle: '' });
+    });
+
+    it('skips malformed entries without a colon', () => {
+      expect(splitFieldStyle('not-a-style')).toEqual({ textStyle: '', boxStyle: '' });
+    });
+
+    it('handles extra whitespace and trailing semicolons', () => {
+      const result = splitFieldStyle('  color : #fff ;  ;  ');
+      expect(result).toEqual({ textStyle: 'color : #fff;', boxStyle: '' });
+    });
+  });
+
+  describe('text-only styles', () => {
+    it('keeps color in textStyle', () => {
+      const result = splitFieldStyle('color:#000;');
+      expect(result.textStyle).toBe('color:#000;');
+      expect(result.boxStyle).toBe('');
+    });
+
+    it('keeps font properties in textStyle', () => {
+      const result = splitFieldStyle('font-family:Arial; font-weight:bold; font-size:1em;');
+      expect(result.textStyle).toBe('font-family:Arial; font-weight:bold; font-size:1em;');
+      expect(result.boxStyle).toBe('');
+    });
+
+    it('keeps letter-spacing and text properties in textStyle', () => {
+      const result = splitFieldStyle('letter-spacing:.12em; text-align:center;');
+      expect(result.textStyle).toBe('letter-spacing:.12em; text-align:center;');
+      expect(result.boxStyle).toBe('');
+    });
+
+    it('keeps unknown properties in textStyle for backward compatibility', () => {
+      const result = splitFieldStyle('custom-prop:value;');
+      expect(result.textStyle).toBe('custom-prop:value;');
+      expect(result.boxStyle).toBe('');
+    });
+  });
+
+  describe('box-model styles', () => {
+    it('puts border in boxStyle', () => {
+      const result = splitFieldStyle('border:1px solid #ccc;');
+      expect(result.textStyle).toBe('');
+      expect(result.boxStyle).toBe('border:1px solid #ccc;');
+    });
+
+    it('puts border variants in boxStyle', () => {
+      const result = splitFieldStyle('border-top:1px solid red; border-radius:4px; border-color:#fff;');
+      expect(result.textStyle).toBe('');
+      expect(result.boxStyle).toBe('border-top:1px solid red; border-radius:4px; border-color:#fff;');
+    });
+
+    it('keeps background properties in textStyle', () => {
+      const result = splitFieldStyle('background-color:#f00; background:blue;');
+      expect(result.textStyle).toBe('background-color:#f00; background:blue;');
+      expect(result.boxStyle).toBe('');
+    });
+
+    it('puts padding in boxStyle', () => {
+      const result = splitFieldStyle('padding:10px; padding-left:5px;');
+      expect(result.textStyle).toBe('');
+      expect(result.boxStyle).toBe('padding:10px; padding-left:5px;');
+    });
+
+    it('puts box-shadow in boxStyle', () => {
+      const result = splitFieldStyle('box-shadow:0 2px 4px rgba(0,0,0,0.1);');
+      expect(result.textStyle).toBe('');
+      expect(result.boxStyle).toBe('box-shadow:0 2px 4px rgba(0,0,0,0.1);');
+    });
+
+    it('puts outline in boxStyle', () => {
+      const result = splitFieldStyle('outline:2px solid blue; outline-offset:3px;');
+      expect(result.textStyle).toBe('');
+      expect(result.boxStyle).toBe('outline:2px solid blue; outline-offset:3px;');
+    });
+  });
+
+  describe('mixed styles', () => {
+    it('correctly splits mixed text and box-model styles', () => {
+      const result = splitFieldStyle('color:#000; border:1px solid #ccc; font-family:Arial;');
+      expect(result.textStyle).toBe('color:#000; font-family:Arial;');
+      expect(result.boxStyle).toBe('border:1px solid #ccc;');
+    });
+  });
+
+  describe('values with colons', () => {
+    it('preserves values containing colons', () => {
+      const result = splitFieldStyle('background-image:url(http://example.com/img.png);');
+      expect(result.textStyle).toBe('background-image:url(http://example.com/img.png);');
+    });
+  });
+
+  describe('real database styles', () => {
+    it('splits Ruby Main position style', () => {
+      const result = splitFieldStyle('font-family:Frobisher, Arial, sans-serif; color:#000; border:solid 1px #ccc;');
+      expect(result.textStyle).toBe('font-family:Frobisher, Arial, sans-serif; color:#000;');
+      expect(result.boxStyle).toBe('border:solid 1px #ccc;');
+    });
+
+    it('puts Waves Main border entirely in boxStyle', () => {
+      const result = splitFieldStyle('border:solid 2px #663333;');
+      expect(result.textStyle).toBe('');
+      expect(result.boxStyle).toBe('border:solid 2px #663333;');
+    });
+
+    it('keeps BlueSwoosh Ticker style entirely in textStyle', () => {
+      const result = splitFieldStyle('color:#FFF; font-family:Frobisher, Arial, sans-serif; font-weight:bold !important;');
+      expect(result.textStyle).toBe('color:#FFF; font-family:Frobisher, Arial, sans-serif; font-weight:bold !important;');
+      expect(result.boxStyle).toBe('');
+    });
+
+    it('keeps BlueSwoosh Time style entirely in textStyle', () => {
+      const result = splitFieldStyle('color:#ccc; font-family:Frobisher, Arial, sans-serif; font-weight:bold !important; letter-spacing:.12em !important;');
+      expect(result.textStyle).toBe('color:#ccc; font-family:Frobisher, Arial, sans-serif; font-weight:bold !important; letter-spacing:.12em !important;');
+      expect(result.boxStyle).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1689. Position styles like borders were applied to the field container, which spans the full position area. Content like graphics doesn't fill this area, so borders floated around empty space instead of hugging the content.

- **Split position styles** via a new `splitFieldStyle` utility: field-level styles (color, font-family, background) stay on the `.field` container; box-model styles (border, padding, box-shadow, outline) are passed to content components as a `boxStyle` prop
- **Switched ConcertoGraphic** from a `background-image` div to an `<img>` tag with `object-fit: contain` inside a flex centering container, so borders hug the scaled image
- **Video components** (YouTube, Vimeo, TikTok) accept and apply `boxStyle` on their `<iframe>`
- **RichText and Clock** intentionally ignore box styles since they fill the full position and borders would just outline the position boundary

## Test plan

- [x] 111 frontend tests passing (21 new `splitFieldStyle` unit tests, 4 new `ConcertoField` integration tests)
- [x] ESLint clean
- [ ] Manual: verify Ruby template border hugs graphics on `/frontend/:id`
- [ ] Manual: verify Waves template border renders correctly
- [ ] Manual: verify BlueSwoosh template (no borders) looks identical to before
- [ ] Manual: verify video content renders correctly with border styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)