### PR TITLE
Split demo build from deployment and default to amd64 only

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -14,13 +14,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx for cache
+        uses: docker/setup-buildx-action@v4
+      - name: Expose GitHub Runtime for cache
+        uses: crazy-max/ghaction-github-runtime@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Build and push image
+        run: bin/kamal build push
+        env:
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     environment:
       name: demo
       url: https://demo.concerto-signage.org/
@@ -33,10 +58,6 @@ jobs:
           tags: tag:ci
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Set up Docker Buildx for cache
-        uses: docker/setup-buildx-action@v4
-      - name: Expose GitHub Runtime for cache
-        uses: crazy-max/ghaction-github-runtime@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -47,7 +68,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy
-        run: bin/kamal deploy
+        run: bin/kamal deploy --skip-push
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}

--- a/config/deploy.release.yml
+++ b/config/deploy.release.yml
@@ -1,0 +1,6 @@
+# Release deployment destination.
+# Adds arm64 to the default amd64 build for multi-arch release images.
+builder:
+  arch:
+    - amd64
+    - arm64

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -78,7 +78,6 @@ asset_path: /rails/public/assets
 builder:
   arch:
     - amd64
-    - arm64
 
   # Using GHA cache
   cache:


### PR DESCRIPTION
## Summary
- Split the demo workflow into separate **build** and **deploy** jobs so a failed deployment can be retried without rebuilding the Docker image
- Default Kamal builder to amd64 only (the common case for every push to main)
- Add a `deploy.release.yml` Kamal destination for multi-arch (amd64 + arm64) release builds
- Add a guard to skip the build when CI fails (`workflow_run.conclusion == 'success'`)

Closes #1710, closes #1711

## Test plan
- [ ] Merge and verify the demo workflow triggers correctly on the next push to main
- [ ] Verify the build job produces an amd64-only image in GHCR
- [ ] Verify the deploy job runs only after build succeeds
- [ ] Test retry: if deploy fails, re-run only the deploy job and confirm it skips the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)