### PR TITLE
Add release workflow for multi-arch Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx for cache
         uses: docker/setup-buildx-action@v4
       - name: Expose GitHub Runtime for cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,12 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      - name: Set version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        if: startsWith(github.ref, 'refs/tags/v')
       - name: Build and push multi-arch image
-        run: bin/kamal build push -d release
+        run: bin/kamal build push -d release ${{ steps.version.outputs.version && format('--version={0}', steps.version.outputs.version) || '' }}
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx for cache
+        uses: docker/setup-buildx-action@v4
+      - name: Expose GitHub Runtime for cache
+        uses: crazy-max/ghaction-github-runtime@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Build and push multi-arch image
+        run: bin/kamal build push -d release
+        env:
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}


### PR DESCRIPTION
## Summary
- Add a new `release.yml` workflow for building multi-arch (amd64 + arm64) Docker images
- Triggered by version tags (`v*`) or manual `workflow_dispatch`
- Uses QEMU for arm64 cross-compilation via `kamal build push -d release`
- No deploy step — just publishes to GHCR

Stacked on #1712.

## Test plan
- [ ] After merging #1712, test with a manual `workflow_dispatch` trigger
- [ ] Verify both amd64 and arm64 manifests are present in the GHCR image
- [ ] Test with a version tag push (e.g., `v3.0.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)