### PR TITLE
Add id-token permission to demo deploy job

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -46,6 +46,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     environment:
       name: demo
       url: https://demo.concerto-signage.org/


### PR DESCRIPTION
## Summary
- The Tailscale GitHub Action in the deploy job requires OIDC authentication
- The deploy job was missing `id-token: write` in its permissions, causing the error: `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`
- The build job already had this permission; this adds it to the deploy job as well


This was broken by #1712.


## Test plan
- [ ] Merge and verify the demo deploy workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)