### PR TITLE
Add secrets.release for Kamal release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,3 @@ jobs:
         run: bin/kamal build push -d release ${{ steps.version.outputs.version && format('--version={0}', steps.version.outputs.version) || '' }}
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}

--- a/.kamal/secrets.release
+++ b/.kamal/secrets.release
@@ -1,3 +1,2 @@
 # Release builds only push images; pull secrets from ENV (set by GitHub Actions).
 KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-SECRET_KEY_BASE=$SECRET_KEY_BASE


### PR DESCRIPTION
## Summary
- Kamal requires a destination-specific secrets file when using `-d release`
- The release workflow (`bin/kamal build push -d release`) was failing because `.kamal/secrets.release` didn't exist
- Error: `Secret 'KAMAL_REGISTRY_PASSWORD' not found, no secret files (.kamal/secrets-common, .kamal/secrets.release) provided`

## Test plan
- [ ] Merge, delete and re-push the `v3.0.0.rc1` tag, and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)