### PR TITLE
Fix footer: replace copyright text and fix broken links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,11 +70,11 @@
       <div class="px-4 py-6 lg:px-6">
         <div class="flex flex-col sm:flex-row justify-between items-center text-caption text-neutral-700">
           <div class="mb-2 sm:mb-0">
-            © <%= Date.current.year %> Concerto Digital Signage. All rights reserved.
+            Powered by <a href="https://github.com/concerto/concerto" class="hover:text-neutral-900">Concerto Digital Signage</a>
           </div>
           <div class="flex space-x-4">
-            <a href="#" class="hover:text-neutral-900">Support</a>
-            <a href="#" class="hover:text-neutral-900">Documentation</a>
+            <a href="https://github.com/concerto/concerto/issues" class="hover:text-neutral-900">Support</a>
+            <a href="https://github.com/concerto/concerto/wiki" class="hover:text-neutral-900">Documentation</a>
             <span class="text-neutral-500">v<%= APP_VERSION %></span>
           </div>
         </div>


### PR DESCRIPTION
Noticed the footer has a couple of small issues (related to #1721):

1. **"All rights reserved"** doesn't really make sense for an open source project, so I replaced it with "Powered by Concerto Digital Signage" with a link back to the repo
2. **Support and Documentation links** both point to `#` — updated them to link to the GitHub issues page and wiki respectively

Pretty small change, just cleaning things up a bit. Let me know if you'd prefer different link targets!