### PR TITLE
Respect video aspect ratio on the player

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -74,6 +74,6 @@ class VideosController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def video_params
-      params.expect(video: policy(@video || Video.new).permitted_attributes + [ :url ])
+      params.expect(video: policy(@video || Video.new).permitted_attributes + [ :url, :aspect_ratio ])
     end
 end

--- a/app/frontend/components/ConcertoTiktokVideo.vue
+++ b/app/frontend/components/ConcertoTiktokVideo.vue
@@ -95,7 +95,7 @@ onBeforeUnmount(() => {
       frameborder="0"
       allow="autoplay; encrypted-media"
       :src="videoUrl"
-      :style="{ aspectRatio: content.aspect_ratio || '9/16' }"
+      :style="{ aspectRatio: content.aspect_ratio }"
     />
   </div>
 </template>

--- a/app/frontend/components/ConcertoTiktokVideo.vue
+++ b/app/frontend/components/ConcertoTiktokVideo.vue
@@ -84,20 +84,33 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <iframe
-    ref="playerRef"
-    class="player"
-    type="text/html"
-    frameborder="0"
-    allow="autoplay; encrypted-media"
-    :src="videoUrl"
+  <div
+    class="video-container"
     :style="boxStyle"
-  />
+  >
+    <iframe
+      ref="playerRef"
+      class="player"
+      type="text/html"
+      frameborder="0"
+      allow="autoplay; encrypted-media"
+      :src="videoUrl"
+      :style="{ aspectRatio: content.aspect_ratio || '9/16' }"
+    />
+  </div>
 </template>
 
 <style scoped>
-.player {
-  height: 100%;
+.video-container {
   width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.player {
+  max-width: 100%;
+  max-height: 100%;
 }
 </style>

--- a/app/frontend/components/ConcertoVimeoVideo.vue
+++ b/app/frontend/components/ConcertoVimeoVideo.vue
@@ -24,6 +24,8 @@ const videoUrl = computed(() => {
 const playerRef = ref(null);
 let player = null;
 
+const aspectRatio = ref(props.content.aspect_ratio || '16/9');
+
 const hasDuration = computed(() => {
   return props.content.duration && props.content.duration > 0;
 });
@@ -72,6 +74,18 @@ onMounted(async () => {
 
   player = new Vimeo.Player(playerRef.value);
 
+  if (props.content.aspect_ratio_auto) {
+    Promise.all([player.getVideoWidth(), player.getVideoHeight()])
+      .then(([width, height]) => {
+        if (width > 0 && height > 0) {
+          aspectRatio.value = `${width}/${height}`;
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to read Vimeo video dimensions:', error);
+      });
+  }
+
   player.on('play', () => {
     console.debug('Vimeo video is playing');
     watchdogPing();
@@ -108,20 +122,33 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <iframe
-    ref="playerRef"
-    class="player"
-    type="text/html"
-    frameborder="0"
-    allow="autoplay"
-    :src="videoUrl"
+  <div
+    class="video-container"
     :style="boxStyle"
-  />
+  >
+    <iframe
+      ref="playerRef"
+      class="player"
+      type="text/html"
+      frameborder="0"
+      allow="autoplay"
+      :src="videoUrl"
+      :style="{ aspectRatio: aspectRatio }"
+    />
+  </div>
 </template>
 
 <style scoped>
-.player {
-  height: 100%;
+.video-container {
   width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.player {
+  max-width: 100%;
+  max-height: 100%;
 }
 </style>

--- a/app/frontend/components/ConcertoVimeoVideo.vue
+++ b/app/frontend/components/ConcertoVimeoVideo.vue
@@ -24,7 +24,7 @@ const videoUrl = computed(() => {
 const playerRef = ref(null);
 let player = null;
 
-const aspectRatio = ref(props.content.aspect_ratio || '16/9');
+const aspectRatio = ref(props.content.aspect_ratio);
 
 const hasDuration = computed(() => {
   return props.content.duration && props.content.duration > 0;

--- a/app/frontend/components/ConcertoYoutubeVideo.vue
+++ b/app/frontend/components/ConcertoYoutubeVideo.vue
@@ -151,7 +151,7 @@ onBeforeUnmount(() => {
       frameborder="0"
       allow="autoplay"
       :src="videoUrl"
-      :style="{ aspectRatio: content.aspect_ratio || '16/9' }"
+      :style="{ aspectRatio: content.aspect_ratio }"
     />
   </div>
 </template>

--- a/app/frontend/components/ConcertoYoutubeVideo.vue
+++ b/app/frontend/components/ConcertoYoutubeVideo.vue
@@ -140,20 +140,33 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <iframe
-    ref="playerRef"
-    class="player"
-    type="text/html"
-    frameborder="0"
-    allow="autoplay"
-    :src="videoUrl"
+  <div
+    class="video-container"
     :style="boxStyle"
-  />
+  >
+    <iframe
+      ref="playerRef"
+      class="player"
+      type="text/html"
+      frameborder="0"
+      allow="autoplay"
+      :src="videoUrl"
+      :style="{ aspectRatio: content.aspect_ratio || '16/9' }"
+    />
+  </div>
 </template>
 
 <style scoped>
-.player {
-  height: 100%;
+.video-container {
   width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.player {
+  max-width: 100%;
+  max-height: 100%;
 }
 </style>

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,10 +4,18 @@ require "cgi"
 class Video < Content
   store_accessor :config, :url, :aspect_ratio
 
-  # Permitted values for the user-facing aspect ratio override.
-  # nil / "auto" means "use the provider default" (with /shorts/ URL detection
-  # for YouTube and dynamic correction for Vimeo on the frontend).
-  ASPECT_RATIOS = [ "auto", "16:9", "9:16", "4:3", "1:1" ].freeze
+  # Permitted values for the user-facing aspect ratio override, with the
+  # labels shown in the form. nil / "auto" means "use the provider default"
+  # (with /shorts/ URL detection for YouTube and dynamic correction for Vimeo
+  # on the frontend).
+  ASPECT_RATIO_OPTIONS = {
+    "auto" => "Auto (detect from source)",
+    "16:9" => "16:9 (widescreen)",
+    "9:16" => "9:16 (vertical)",
+    "4:3" => "4:3 (standard)",
+    "1:1" => "1:1 (square)"
+  }.freeze
+  ASPECT_RATIOS = ASPECT_RATIO_OPTIONS.keys.freeze
 
   validates :aspect_ratio, inclusion: { in: ASPECT_RATIOS }, allow_blank: true
 
@@ -25,10 +33,10 @@ class Video < Content
   # user has not set an explicit override.
   def effective_aspect_ratio
     ratio = aspect_ratio
-    return css_ratio(ratio) if ratio.present? && ratio != "auto"
+    return ratio.tr(":", "/") if ratio.present? && ratio != "auto"
 
     case video_source
-    when "youtube" then youtube_default_ratio
+    when "youtube" then url.to_s.include?("/shorts/") ? "9/16" : "16/9"
     when "tiktok" then "9/16"
     else "16/9"
     end
@@ -100,14 +108,6 @@ class Video < Content
   end
 
   private
-
-  def css_ratio(ratio)
-    ratio.tr(":", "/")
-  end
-
-  def youtube_default_ratio
-    url.to_s.include?("/shorts/") ? "9/16" : "16/9"
-  end
 
   # Memoized helper to fetch Vimeo oEmbed data once per request
   def vimeo_oembed_data

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -2,13 +2,36 @@ require "net/http"
 require "cgi"
 
 class Video < Content
-  store_accessor :config, :url
+  store_accessor :config, :url, :aspect_ratio
+
+  # Permitted values for the user-facing aspect ratio override.
+  # nil / "auto" means "use the provider default" (with /shorts/ URL detection
+  # for YouTube and dynamic correction for Vimeo on the frontend).
+  ASPECT_RATIOS = [ "auto", "16:9", "9:16", "4:3", "1:1" ].freeze
+
+  validates :aspect_ratio, inclusion: { in: ASPECT_RATIOS }, allow_blank: true
 
   def as_json(options = {})
     super(options).merge({
       video_id: video_id,
-      video_source: video_source
+      video_source: video_source,
+      aspect_ratio: effective_aspect_ratio,
+      aspect_ratio_auto: aspect_ratio.blank? || aspect_ratio == "auto"
     })
+  end
+
+  # Resolves the CSS-ready aspect ratio string (e.g. "16/9") the frontend should
+  # use as the initial rendering ratio. Falls back to provider defaults when the
+  # user has not set an explicit override.
+  def effective_aspect_ratio
+    ratio = aspect_ratio
+    return css_ratio(ratio) if ratio.present? && ratio != "auto"
+
+    case video_source
+    when "youtube" then youtube_default_ratio
+    when "tiktok" then "9/16"
+    else "16/9"
+    end
   end
 
   # For now, videos should only be rendered in positions that are roughly
@@ -77,6 +100,14 @@ class Video < Content
   end
 
   private
+
+  def css_ratio(ratio)
+    ratio.tr(":", "/")
+  end
+
+  def youtube_default_ratio
+    url.to_s.include?("/shorts/") ? "9/16" : "16/9"
+  end
 
   # Memoized helper to fetch Vimeo oEmbed data once per request
   def vimeo_oembed_data

--- a/app/views/videos/_form.html.erb
+++ b/app/views/videos/_form.html.erb
@@ -43,17 +43,11 @@
         <div>
           <%= form.label :aspect_ratio, "Aspect Ratio", class: "block text-sm font-medium text-gray-700 mb-2" %>
           <%= form.select :aspect_ratio,
-              [
-                [ "Auto (detect from source)", "auto" ],
-                [ "16:9 (widescreen)", "16:9" ],
-                [ "9:16 (vertical)", "9:16" ],
-                [ "4:3 (standard)", "4:3" ],
-                [ "1:1 (square)", "1:1" ]
-              ],
+              Video::ASPECT_RATIO_OPTIONS.map { |value, label| [ label, value ] },
               { selected: video.aspect_ratio.presence || "auto" },
               class: "block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm" %>
           <p class="text-xs text-gray-500 mt-1">
-            Override when auto-detection is wrong — for example, YouTube Shorts shared via a <code>watch?v=</code> link.
+            Override when auto-detection is wrong — for example, a YouTube Short linked via a <code>watch?v=</code> URL.
           </p>
         </div>
 

--- a/app/views/videos/_form.html.erb
+++ b/app/views/videos/_form.html.erb
@@ -39,6 +39,24 @@
           </p>
         </div>
 
+        <!-- Aspect Ratio -->
+        <div>
+          <%= form.label :aspect_ratio, "Aspect Ratio", class: "block text-sm font-medium text-gray-700 mb-2" %>
+          <%= form.select :aspect_ratio,
+              [
+                [ "Auto (detect from source)", "auto" ],
+                [ "16:9 (widescreen)", "16:9" ],
+                [ "9:16 (vertical)", "9:16" ],
+                [ "4:3 (standard)", "4:3" ],
+                [ "1:1 (square)", "1:1" ]
+              ],
+              { selected: video.aspect_ratio.presence || "auto" },
+              class: "block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm" %>
+          <p class="text-xs text-gray-500 mt-1">
+            Override when auto-detection is wrong — for example, YouTube Shorts shared via a <code>watch?v=</code> link.
+          </p>
+        </div>
+
         <%= render "contents/form", form: form %>
       </div>
     </div>

--- a/test/controllers/videos_controller_test.rb
+++ b/test/controllers/videos_controller_test.rb
@@ -117,4 +117,30 @@ class VideosControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
     assert_equal "You are not authorized to perform this action.", flash[:alert]
   end
+
+  test "should persist aspect_ratio on create" do
+    sign_in @user
+    assert_difference("Video.count") do
+      post videos_url, params: { video: {
+        duration: @video.duration, end_time: @video.end_time,
+        name: @video.name, start_time: @video.start_time,
+        url: @video.url, aspect_ratio: "9:16"
+      } }
+    end
+    assert_equal "9:16", Video.last.aspect_ratio
+  end
+
+  test "should persist aspect_ratio on update" do
+    sign_in @user
+    patch video_url(@video), params: { video: { aspect_ratio: "1:1" } }
+    assert_redirected_to video_url(@video)
+    assert_equal "1:1", @video.reload.aspect_ratio
+  end
+
+  test "should reject invalid aspect_ratio on update" do
+    sign_in @user
+    patch video_url(@video), params: { video: { aspect_ratio: "21:9" } }
+    assert_response :unprocessable_entity
+    assert_nil @video.reload.aspect_ratio
+  end
 end

--- a/test/frontend/components/ConcertoTiktokVideo.test.js
+++ b/test/frontend/components/ConcertoTiktokVideo.test.js
@@ -14,14 +14,7 @@ describe('ConcertoTiktokVideo', () => {
     expect(iframe.attributes('src')).toBe('https://www.tiktok.com/player/v1/6718335390845095173?autoplay=1&muted=1&loop=0&controls=0');
   })
 
-  it('defaults to 9/16 aspect ratio', () => {
-    const wrapper = mount(ConcertoTiktokVideo, {
-      props: { content: { video_id: '6718335390845095173' } }
-    });
-    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 9/16');
-  })
-
-  it('respects a backend-provided aspect_ratio', () => {
+  it('applies the backend-provided aspect_ratio', () => {
     const wrapper = mount(ConcertoTiktokVideo, {
       props: { content: { video_id: '6718335390845095173', aspect_ratio: '1/1' } }
     });

--- a/test/frontend/components/ConcertoTiktokVideo.test.js
+++ b/test/frontend/components/ConcertoTiktokVideo.test.js
@@ -13,6 +13,20 @@ describe('ConcertoTiktokVideo', () => {
     const iframe = wrapper.find('iframe');
     expect(iframe.attributes('src')).toBe('https://www.tiktok.com/player/v1/6718335390845095173?autoplay=1&muted=1&loop=0&controls=0');
   })
+
+  it('defaults to 9/16 aspect ratio', () => {
+    const wrapper = mount(ConcertoTiktokVideo, {
+      props: { content: { video_id: '6718335390845095173' } }
+    });
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 9/16');
+  })
+
+  it('respects a backend-provided aspect_ratio', () => {
+    const wrapper = mount(ConcertoTiktokVideo, {
+      props: { content: { video_id: '6718335390845095173', aspect_ratio: '1/1' } }
+    });
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 1/1');
+  })
 })
 
 describe('ConcertoTiktokVideo duration control', () => {

--- a/test/frontend/components/ConcertoVimeoVideo.test.js
+++ b/test/frontend/components/ConcertoVimeoVideo.test.js
@@ -21,13 +21,6 @@ describe('ConcertoVimeoVideo', () => {
     expect(wrapper.html()).toContain('src="https://player.vimeo.com/video/123456789?autoplay=1&amp;muted=1&amp;loop=0&amp;api=1&amp;background=1"');
   });
 
-  it('defaults to a 16/9 aspect ratio when backend value is missing', () => {
-    const wrapper = mount(ConcertoVimeoVideo, {
-      props: { content: { video_id: '123456789' } }
-    });
-    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 16/9');
-  });
-
   it('applies a backend-provided aspect_ratio', () => {
     const wrapper = mount(ConcertoVimeoVideo, {
       props: { content: { video_id: '123456789', aspect_ratio: '4/3' } }

--- a/test/frontend/components/ConcertoVimeoVideo.test.js
+++ b/test/frontend/components/ConcertoVimeoVideo.test.js
@@ -20,6 +20,58 @@ describe('ConcertoVimeoVideo', () => {
 
     expect(wrapper.html()).toContain('src="https://player.vimeo.com/video/123456789?autoplay=1&amp;muted=1&amp;loop=0&amp;api=1&amp;background=1"');
   });
+
+  it('defaults to a 16/9 aspect ratio when backend value is missing', () => {
+    const wrapper = mount(ConcertoVimeoVideo, {
+      props: { content: { video_id: '123456789' } }
+    });
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 16/9');
+  });
+
+  it('applies a backend-provided aspect_ratio', () => {
+    const wrapper = mount(ConcertoVimeoVideo, {
+      props: { content: { video_id: '123456789', aspect_ratio: '4/3' } }
+    });
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 4/3');
+  });
+});
+
+describe('ConcertoVimeoVideo dynamic aspect ratio', () => {
+  let mockPlayer;
+
+  beforeEach(() => {
+    mockPlayer = {
+      on: vi.fn(),
+      getVideoWidth: vi.fn().mockResolvedValue(1080),
+      getVideoHeight: vi.fn().mockResolvedValue(1920),
+    };
+    global.Vimeo.Player.mockImplementation(function() {
+      return mockPlayer;
+    });
+  });
+
+  it('updates aspect ratio from the Player API when aspect_ratio_auto is true', async () => {
+    const wrapper = mount(ConcertoVimeoVideo, {
+      props: { content: { video_id: '123456789', aspect_ratio: '16/9', aspect_ratio_auto: true } }
+    });
+
+    // Wait for the getVideoWidth/getVideoHeight promises to settle.
+    await vi.waitFor(() => {
+      expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 1080/1920');
+    });
+  });
+
+  it('does not override the user-provided ratio when aspect_ratio_auto is false', async () => {
+    const wrapper = mount(ConcertoVimeoVideo, {
+      props: { content: { video_id: '123456789', aspect_ratio: '16/9', aspect_ratio_auto: false } }
+    });
+
+    // Allow any pending microtasks to flush before asserting no change.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockPlayer.getVideoWidth).not.toHaveBeenCalled();
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 16/9');
+  });
 });
 
 describe('ConcertoVimeoVideo duration control', () => {

--- a/test/frontend/components/ConcertoYoutubeVideo.test.js
+++ b/test/frontend/components/ConcertoYoutubeVideo.test.js
@@ -16,6 +16,23 @@ describe('ConcertoYoutubeVideo', () => {
 
     expect(wrapper.html()).toContain('src="https://www.youtube-nocookie.com/embed/z7HyF46-Zd0?rel=0&amp;iv_load_policy=3&amp;autoplay=1');
   })
+
+  it('applies the backend-provided aspect ratio to the iframe', () => {
+    const content = {
+      video_id: 'z7HyF46-Zd0',
+      aspect_ratio: '9/16'
+    };
+    const wrapper = mount(ConcertoYoutubeVideo, { props: { content: content } });
+
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 9/16');
+  })
+
+  it('falls back to 16/9 when aspect_ratio is missing', () => {
+    const content = { video_id: 'z7HyF46-Zd0' };
+    const wrapper = mount(ConcertoYoutubeVideo, { props: { content: content } });
+
+    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 16/9');
+  })
 })
 
 describe('ConcertoYoutubeVideo duration control', () => {

--- a/test/frontend/components/ConcertoYoutubeVideo.test.js
+++ b/test/frontend/components/ConcertoYoutubeVideo.test.js
@@ -26,13 +26,6 @@ describe('ConcertoYoutubeVideo', () => {
 
     expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 9/16');
   })
-
-  it('falls back to 16/9 when aspect_ratio is missing', () => {
-    const content = { video_id: 'z7HyF46-Zd0' };
-    const wrapper = mount(ConcertoYoutubeVideo, { props: { content: content } });
-
-    expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 16/9');
-  })
 })
 
 describe('ConcertoYoutubeVideo duration control', () => {

--- a/test/models/video_test.rb
+++ b/test/models/video_test.rb
@@ -53,4 +53,61 @@ class VideoTest < ActiveSupport::TestCase
     assert_equal "6718335390845095173", tiktok_json[:video_id]
     assert_equal "tiktok", tiktok_json[:video_source]
   end
+
+  test "effective_aspect_ratio defaults to 16/9 for regular YouTube videos" do
+    assert_equal "16/9", @youtube_video.effective_aspect_ratio
+  end
+
+  test "effective_aspect_ratio defaults to 9/16 for YouTube shorts URLs" do
+    assert_equal "9/16", @youtube_short.effective_aspect_ratio
+  end
+
+  test "effective_aspect_ratio defaults to 9/16 for TikTok" do
+    assert_equal "9/16", @tiktok_video.effective_aspect_ratio
+  end
+
+  test "effective_aspect_ratio defaults to 16/9 for Vimeo" do
+    assert_equal "16/9", @vimeo_video.effective_aspect_ratio
+  end
+
+  test "user-set aspect_ratio overrides provider default" do
+    @youtube_video.aspect_ratio = "9:16"
+    assert_equal "9/16", @youtube_video.effective_aspect_ratio
+  end
+
+  test "aspect_ratio of 'auto' falls back to provider default" do
+    @youtube_video.aspect_ratio = "auto"
+    assert_equal "16/9", @youtube_video.effective_aspect_ratio
+    assert @youtube_video.as_json[:aspect_ratio_auto]
+  end
+
+  test "as_json exposes aspect_ratio and aspect_ratio_auto" do
+    json = @youtube_video.as_json
+    assert_equal "16/9", json[:aspect_ratio]
+    assert json[:aspect_ratio_auto]
+
+    @youtube_video.aspect_ratio = "1:1"
+    json = @youtube_video.as_json
+    assert_equal "1/1", json[:aspect_ratio]
+    assert_not json[:aspect_ratio_auto]
+  end
+
+  test "aspect_ratio validation rejects unknown values" do
+    @youtube_video.aspect_ratio = "21:9"
+    assert_not @youtube_video.valid?
+    assert_includes @youtube_video.errors[:aspect_ratio], "is not included in the list"
+  end
+
+  test "aspect_ratio validation accepts blank and listed values" do
+    Video::ASPECT_RATIOS.each do |ratio|
+      @youtube_video.aspect_ratio = ratio
+      assert @youtube_video.valid?, "expected #{ratio.inspect} to be valid"
+    end
+
+    @youtube_video.aspect_ratio = nil
+    assert @youtube_video.valid?
+
+    @youtube_video.aspect_ratio = ""
+    assert @youtube_video.valid?
+  end
 end


### PR DESCRIPTION
Fixes #1761.

## Summary

Video iframes no longer stretch to fill the field. Each video component now wraps the iframe in a centered container and constrains it to an aspect ratio, so the surrounding space shows the template background instead of the embed player's black letterbox.

Ratios are computed server-side (`Video#effective_aspect_ratio`) with these defaults:
- **YouTube:** `16/9`, or `9/16` when the URL contains `/shorts/`
- **Vimeo:** `16/9`, then dynamically corrected on the frontend via `player.getVideoWidth()` / `getVideoHeight()` when the user hasn't set an override
- **TikTok:** `9/16`

YouTube's IFrame API has no equivalent to Vimeo's dimension getters (confirmed against the current API reference), and YouTube oEmbed always returns `200x113` regardless of the video's true orientation — so there's no reliable dynamic signal. To handle the remaining case (e.g. a vertical Short shared as a `watch?v=` link), a new "Aspect Ratio" selector on the video form lets the author override the default per video.

## Design notes

- New `Video::ASPECT_RATIOS` whitelist: `auto`, `16:9`, `9:16`, `4:3`, `1:1` (stored in the existing `config` JSON via `store_accessor`, no migration needed).
- `Video#as_json` exposes `aspect_ratio` (CSS-ready, e.g. `"9/16"`) and `aspect_ratio_auto` (bool) so the Vimeo component knows when it's safe to override from the Player API.
- Provider default/Shorts-URL logic lives in the model so the frontend stays thin.

## Test plan
- [x] `bin/rails test` (917 runs, 0 failures)
- [x] `yarn run vitest run` (13 files, 119 passed / 1 skipped)
- [x] `bundle exec rubocop` (no offenses)
- [x] `yarn run eslint "{app,test}/frontend/**/*.{js,vue}"` (clean)
- [x] Model tests cover per-provider defaults, Shorts URL detection, user override, `auto` fallback, validation.
- [x] Controller tests cover `aspect_ratio` permit/reject.
- [x] Frontend tests verify iframe `aspect-ratio` style per provider, and Vimeo dynamic correction only when `aspect_ratio_auto` is true.
- [ ] Manual browser smoke-test with a regular 16:9 YouTube, a `/shorts/` URL, a vertical Vimeo, a TikTok, and a manually-overridden video — confirm letterboxing against template background rather than black bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)