### PR TITLE
Validate Graphic image content type, fix 500 on unsupported files

### DIFF
--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -5,6 +5,8 @@ class Graphic < Content
 
   store_accessor :config, :conversion_error
 
+  SUPPORTED_CONTENT_TYPES = (ActiveStorage.variable_content_types + [ "application/pdf" ]).freeze
+
   # URL Helpers are needed so we can generate a URL to the image in the JSON.
   include Rails.application.routes.url_helpers
 
@@ -12,6 +14,8 @@ class Graphic < Content
   before_save :track_image_change
   after_commit :reevaluate_submissions_for_image_change, on: [ :create, :update ]
   after_commit :convert_pdf_to_image_if_needed, on: [ :create, :update ]
+
+  validate :image_content_type_supported, if: -> { image.attached? }
 
   def as_json(options = {})
     super(options).merge({
@@ -31,7 +35,7 @@ class Graphic < Content
   #
   # There is room to improve this algorithm. I just made up 2.0.
   def should_render_in?(position)
-    return false if processing?
+    return false unless image.attached? && image.variable?
 
     if !image.analyzed?
       logger.debug "graphic #{id} not analyzed, fallback rendering"
@@ -66,5 +70,10 @@ class Graphic < Content
 
     update_column(:config, (config || {}).except("conversion_error")) if conversion_error.present?
     ConvertPdfToImageJob.perform_later(self)
+  end
+
+  def image_content_type_supported
+    return if SUPPORTED_CONTENT_TYPES.include?(image.content_type)
+    errors.add(:image, "is not a supported format")
   end
 end

--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -74,6 +74,6 @@ class Graphic < Content
 
   def image_content_type_supported
     return if SUPPORTED_CONTENT_TYPES.include?(image.content_type)
-    errors.add(:image, "is not a supported format")
+    errors.add(:image, "type #{image.content_type} is not supported")
   end
 end

--- a/app/views/graphics/_graphic.html.erb
+++ b/app/views/graphics/_graphic.html.erb
@@ -22,12 +22,16 @@
             <span class="text-sm font-medium">Converting PDF to image&hellip;</span>
           </div>
         <% end %>
-      <% else %>
+      <% elsif graphic.image.attached? && graphic.image.variable? %>
         <div class="flex justify-center">
           <%= link_to graphic.image, class: "block" do %>
             <%= image_tag graphic.image.variant(:grid),
                 class: "max-w-full h-auto rounded-lg shadow-sm border border-neutral-200" %>
           <% end %>
+        </div>
+      <% elsif graphic.image.attached? %>
+        <div class="flex items-center justify-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-8 text-neutral-500">
+          <span class="text-sm">Unsupported file format</span>
         </div>
       <% end %>
     </div>

--- a/app/views/graphics/_grid.html.erb
+++ b/app/views/graphics/_grid.html.erb
@@ -1,4 +1,4 @@
-<% if !content.processing? %>
+<% if content.image.attached? && content.image.variable? %>
   <%= image_tag content.image.variant(:grid), class: "object-contain" %>
 <% else %>
   <div class="flex h-full items-center justify-center text-xs text-gray-400">Processing&hellip;</div>

--- a/test/controllers/graphics_controller_test.rb
+++ b/test/controllers/graphics_controller_test.rb
@@ -91,6 +91,27 @@ class GraphicsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to contents_url
   end
 
+  test "should reject unsupported file type on create" do
+    sign_in @user
+    assert_no_difference("Graphic.count") do
+      post graphics_url, params: { graphic: {
+        name: "Bad upload", duration: 10,
+        image: fixture_file_upload("no_xml.zip", "application/zip")
+      } }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "should reject unsupported file type on update" do
+    sign_in @user
+    patch graphic_url(@graphic), params: { graphic: {
+      image: fixture_file_upload("no_xml.zip", "application/zip")
+    } }
+    assert_response :unprocessable_entity
+    @graphic.reload
+    assert_equal "image/jpeg", @graphic.image.content_type
+  end
+
   # Authorization tests
   test "should not allow non-owner to edit graphic" do
     sign_in users(:non_member)

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -22,6 +22,35 @@ class GraphicTest < ActiveSupport::TestCase
     assert_not graphics(:pdf_graphic).should_render_in?(positions(:two_graphic))
   end
 
+  test "accepts supported image content types" do
+    Graphic::SUPPORTED_CONTENT_TYPES.excluding("application/pdf").each do |content_type|
+      graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
+      graphic.image.attach(io: StringIO.new("data"), filename: "test", content_type: content_type)
+      graphic.valid?
+      assert_empty graphic.errors[:image], "Expected #{content_type} to be valid"
+    end
+  end
+
+  test "accepts PDF uploads" do
+    graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: file_fixture("flyer.pdf").open, filename: "flyer.pdf", content_type: "application/pdf")
+    graphic.valid?
+    assert_empty graphic.errors[:image]
+  end
+
+  test "rejects unsupported content types" do
+    graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: StringIO.new("data"), filename: "test.exe", content_type: "application/octet-stream")
+    assert_not graphic.valid?
+    assert_includes graphic.errors[:image], "is not a supported format"
+  end
+
+  test "does not render unsupported content types in player" do
+    graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: StringIO.new("data"), filename: "test.exe", content_type: "application/octet-stream")
+    assert_not graphic.should_render_in?(positions(:two_graphic))
+  end
+
   test "enqueues conversion job when PDF is attached on create" do
     graphic = Graphic.new(name: "PDF Test", duration: 10, user: users(:admin))
     graphic.image.attach(io: file_fixture("flyer.pdf").open, filename: "flyer.pdf", content_type: "application/pdf")

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -42,7 +42,7 @@ class GraphicTest < ActiveSupport::TestCase
     graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
     graphic.image.attach(io: StringIO.new("data"), filename: "test.exe", content_type: "application/octet-stream")
     assert_not graphic.valid?
-    assert_includes graphic.errors[:image], "is not a supported format"
+    assert_match(/type .+ is not supported/, graphic.errors[:image].first)
   end
 
   test "does not render unsupported content types in player" do


### PR DESCRIPTION
Closes #1768

## Summary

- Unsupported file uploads are now rejected at the model layer with a clear validation error ("Image is not a supported format") — the file is never stored
- The allowlist is `ActiveStorage.variable_content_types + ["application/pdf"]`, so it stays current with whatever Rails/libvips supports without code changes
- Defense-in-depth: `_graphic.html.erb` now shows an "Unsupported file format" placeholder instead of 500ing on records already in the database; `_grid.html.erb` and `should_render_in?` use `image.variable?` for the same reason

## Test plan

- [ ] Upload an unsupported file (e.g. `.exe`, `.zip`) — expect a form validation error, no file stored
- [ ] Upload a supported image (JPG, PNG, WebP) — expect normal behaviour
- [ ] Upload a PDF — expect conversion spinner as before
- [ ] `bin/rails test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)