### PR TITLE
Render background images with parentheses in the filename

### DIFF
--- a/app/frontend/components/ConcertoScreen.vue
+++ b/app/frontend/components/ConcertoScreen.vue
@@ -27,7 +27,7 @@ const backgroundImageStyle = computed(() => {
   if (!backgroundImage.value) return 'none';
   // Quote the URL so parentheses or other special characters in the
   // filename (e.g. "tall (1).png") don't terminate the CSS url() function.
-  const escaped = backgroundImage.value.replace(/(["\\])/g, '\\$1');
+  const escaped = backgroundImage.value.replace(/(["\\\n\r])/g, '\\$1');
   return `url("${escaped}")`;
 });
 

--- a/app/frontend/components/ConcertoScreen.vue
+++ b/app/frontend/components/ConcertoScreen.vue
@@ -24,7 +24,11 @@ const { check: checkConfigVersion } = useConfigVersion('Screen');
 useWakeLock();
 
 const backgroundImageStyle = computed(() => {
-  return backgroundImage.value ? `url(${backgroundImage.value})` : 'none';
+  if (!backgroundImage.value) return 'none';
+  // Quote the URL so parentheses or other special characters in the
+  // filename (e.g. "tall (1).png") don't terminate the CSS url() function.
+  const escaped = backgroundImage.value.replace(/(["\\])/g, '\\$1');
+  return `url("${escaped}")`;
 });
 
 async function loadConfig(retryCount = 0) {

--- a/test/frontend/components/ConcertoScreen.test.js
+++ b/test/frontend/components/ConcertoScreen.test.js
@@ -89,7 +89,7 @@ describe('ConcertoScreen', () => {
     await flushPromises();
 
     const screen = wrapper.get('.screen');
-    expect(screen.attributes('style')).toContain('url(http://server/BlueSwooshNeo_16x9.jpg);');
+    expect(screen.attributes('style')).toContain('url("http://server/BlueSwooshNeo_16x9.jpg");');
     
     const fields = wrapper.findAllComponents(ConcertoField);
     expect(fields).toHaveLength(4);
@@ -102,5 +102,29 @@ describe('ConcertoScreen', () => {
     expect(fields[1].html()).toContain(screenSetup.positions[1].style);
 
     expect(fields[2].html()).toContain(screenSetup.positions[2].content_uri);
+  })
+
+  it('quotes background URLs containing parentheses', async () => {
+    // Regression for #1773: filenames like "tall (1).png" produce URLs
+    // with raw parens that terminate an unquoted CSS url() function.
+    const trickyUrl = 'http://server/blobs/tall_yes%20(1).png';
+    server.use(
+      http.get(screenSetupUrl, () => {
+        return HttpResponse.json({
+          template: { background_uri: trickyUrl },
+          positions: []
+        });
+      })
+    );
+
+    const wrapper = mount(ConcertoScreen, {
+      props: { apiUrl: screenSetupUrl },
+      global: { stubs: { ConcertoField: true } }
+    });
+
+    await flushPromises();
+
+    expect(wrapper.get('.screen').attributes('style'))
+      .toContain(`url("${trickyUrl}");`);
   })
 })


### PR DESCRIPTION
## Summary
- Wrap the screen background URL in quotes inside the CSS `url(...)` so filenames with raw parentheses (e.g. `tall (1).png`) don't terminate the function and silently drop the declaration.
- Defensively escape any `"`/`\` in the URL so the quoting itself can't be broken.
- Update the existing ConcertoScreen test for the new quoted form and add a regression test using a parenthesized filename.

Closes #1773

## Test plan
- [x] `yarn run vitest run test/frontend/components/ConcertoScreen.test.js` (existing + new regression test pass)
- [x] `yarn run vitest run` (full frontend suite)
- [x] `yarn run eslint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)