### PR TITLE
Render portrait graphics in similarly-shaped positions

### DIFF
--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -47,7 +47,7 @@ class Graphic < Content
       return super
     end
 
-    content_aspect_ratio = image.metadata[:width] / image.metadata[:height]
+    content_aspect_ratio = image.metadata[:width].fdiv(image.metadata[:height])
     position_aspect_ratio = position.aspect_ratio
 
     (position_aspect_ratio / 2.0) <= content_aspect_ratio && content_aspect_ratio <= (position_aspect_ratio * 2.0)

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -47,3 +47,8 @@ pdf_graphic_image:
   name: image
   record: pdf_graphic (Content)
   blob: pdf_graphic_blob
+
+portrait_graphic_image:
+  name: image
+  record: portrait_graphic (Content)
+  blob: portrait_graphic_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -2,3 +2,4 @@ one_graphic_blob: <%= ActiveStorage::FixtureSet.blob filename: "one.jpg", servic
 two_graphic_blob: <%= ActiveStorage::FixtureSet.blob filename: "two.jpg", service_name: "test_fixtures", metadata: {identified: true, width: 4032, height: 3024, analyzed: true} %>
 two_template_blob: <%= ActiveStorage::FixtureSet.blob filename: "template.jpg", service_name: "test_fixtures", metadata: {identified: true, width: 1920, height: 1080, analyzed: true} %>
 pdf_graphic_blob: <%= ActiveStorage::FixtureSet.blob filename: "flyer.pdf", service_name: "test_fixtures", metadata: {identified: true, analyzed: false} %>
+portrait_graphic_blob: <%= ActiveStorage::FixtureSet.blob filename: "template_portrait.png", service_name: "test_fixtures", metadata: {identified: true, width: 768, height: 1376, analyzed: true} %>

--- a/test/fixtures/graphics.yml
+++ b/test/fixtures/graphics.yml
@@ -66,3 +66,9 @@ pdf_graphic:
   name: "PDF Flyer"
   duration: 30
   user: admin
+
+portrait_graphic:
+  type: Graphic
+  name: "Portrait Graphic"
+  duration: 30
+  user: admin

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -22,6 +22,12 @@ class GraphicTest < ActiveSupport::TestCase
     assert_not graphics(:pdf_graphic).should_render_in?(positions(:two_graphic))
   end
 
+  test "renders portrait images in similarly-shaped positions" do
+    portrait = graphics(:portrait_graphic)
+    assert portrait.should_render_in?(positions(:two_graphic))
+    assert_not portrait.should_render_in?(positions(:two_ticker))
+  end
+
   test "accepts supported image content types" do
     Graphic::SUPPORTED_CONTENT_TYPES.excluding("application/pdf").each do |content_type|
       graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))


### PR DESCRIPTION
## Summary
- Fix integer division in `Graphic#should_render_in?` so portrait images get a real fractional aspect ratio instead of always collapsing to `0`. Before this change, any image where width < height failed the position fit check regardless of the position's shape.
- Add a portrait fixture (768×1376 PNG) and assert it renders in a portrait-leaning main position but not in the ticker.

Fixes #1766.

The 2× tolerance window is unchanged; per the analysis on the issue thread, every "main" position in the seed file (aspect ratios 0.73–1.0) accepts standard portrait content (PDFs, A4, Letter, 9:16 phone) once the integer-division bug is gone. Loosening the heuristic itself is a separable design call.

## Test plan
- [x] `bin/rails test` (930 tests pass)
- [x] `bundle exec rubocop app/models/graphic.rb test/models/graphic_test.rb` clean
- [ ] Manually verify the two portrait graphics (29, 30) now render in screen 2, field 1, position 25 in the dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)