### PR TITLE
Shrink clock text to fit narrow time fields

### DIFF
--- a/app/frontend/composables/useTextResize.js
+++ b/app/frontend/composables/useTextResize.js
@@ -24,8 +24,8 @@ export function useTextResize() {
       return
     }
 
-    const fieldHeight = containerElement.offsetHeight
-    const fieldWidth = containerElement.offsetWidth
+    const fieldHeight = containerElement.clientHeight
+    const fieldWidth = containerElement.clientWidth
     const initialHeight = childElement.scrollHeight
 
     if (initialHeight === 0 || fieldHeight === 0 || fieldWidth === 0) {

--- a/app/frontend/composables/useTextResize.js
+++ b/app/frontend/composables/useTextResize.js
@@ -25,15 +25,16 @@ export function useTextResize() {
     }
 
     const fieldHeight = containerElement.offsetHeight
+    const fieldWidth = containerElement.offsetWidth
     const initialHeight = childElement.scrollHeight
 
-    if (initialHeight === 0 || fieldHeight === 0) {
-      console.error('Cannot resize text: zero height detected.')
+    if (initialHeight === 0 || fieldHeight === 0 || fieldWidth === 0) {
+      console.error('Cannot resize text: zero dimension detected.')
       return
     }
 
     if (import.meta.env.DEV) {
-      console.debug(`Field height: ${fieldHeight}, Initial content height: ${initialHeight}`)
+      console.debug(`Field: ${fieldWidth}x${fieldHeight}, Initial content height: ${initialHeight}`)
     }
 
     // Use binary search to find optimal font size
@@ -43,15 +44,18 @@ export function useTextResize() {
     let maxSize = MAX_FONT_SIZE
     let bestSize = MIN_FONT_SIZE
 
-    // Binary search for the largest font size that fits
+    // Binary search for the largest font size that fits both dimensions.
+    // Width matters for non-wrapping content (e.g. clock with white-space: nowrap)
+    // where horizontal overflow doesn't cause vertical overflow.
     while (minSize <= maxSize) {
       const midSize = Math.floor((minSize + maxSize) / 2)
 
       // Set the font size and measure once
       containerElement.style.fontSize = `${midSize}%`
       const currentHeight = containerElement.scrollHeight
+      const currentWidth = containerElement.scrollWidth
 
-      if (currentHeight <= fieldHeight) {
+      if (currentHeight <= fieldHeight && currentWidth <= fieldWidth) {
         // This size fits, try larger
         bestSize = midSize
         minSize = midSize + 1

--- a/test/frontend/composables/useTextResize.test.js
+++ b/test/frontend/composables/useTextResize.test.js
@@ -23,8 +23,8 @@ function mockLayout(wrapper, { fieldWidth, fieldHeight, naturalWidth, naturalHei
   const containerEl = wrapper.vm.containerRef
   const childEl = wrapper.vm.childRef
 
-  Object.defineProperty(containerEl, 'offsetWidth', { configurable: true, get: () => fieldWidth })
-  Object.defineProperty(containerEl, 'offsetHeight', { configurable: true, get: () => fieldHeight })
+  Object.defineProperty(containerEl, 'clientWidth', { configurable: true, get: () => fieldWidth })
+  Object.defineProperty(containerEl, 'clientHeight', { configurable: true, get: () => fieldHeight })
 
   const fontPercent = () => parseFloat(containerEl.style.fontSize) || 100
   Object.defineProperty(containerEl, 'scrollWidth', {

--- a/test/frontend/composables/useTextResize.test.js
+++ b/test/frontend/composables/useTextResize.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { useTextResize } from '../../../app/frontend/composables/useTextResize.js'
+
+/* global global */
+
+const TestComponent = {
+  template: `
+    <div ref="containerRef">
+      <div ref="childRef">content</div>
+    </div>
+  `,
+  setup() {
+    return useTextResize()
+  }
+}
+
+// JSDOM doesn't lay out content, so we mock layout: scrollHeight and scrollWidth
+// on the container scale linearly with the font-size percent set on it. The
+// "natural" size at 100% font is configurable to simulate wide vs tall content.
+function mockLayout(wrapper, { fieldWidth, fieldHeight, naturalWidth, naturalHeight }) {
+  const containerEl = wrapper.vm.containerRef
+  const childEl = wrapper.vm.childRef
+
+  Object.defineProperty(containerEl, 'offsetWidth', { configurable: true, get: () => fieldWidth })
+  Object.defineProperty(containerEl, 'offsetHeight', { configurable: true, get: () => fieldHeight })
+
+  const fontPercent = () => parseFloat(containerEl.style.fontSize) || 100
+  Object.defineProperty(containerEl, 'scrollWidth', {
+    configurable: true,
+    get: () => Math.ceil(naturalWidth * fontPercent() / 100)
+  })
+  Object.defineProperty(containerEl, 'scrollHeight', {
+    configurable: true,
+    get: () => Math.ceil(naturalHeight * fontPercent() / 100)
+  })
+
+  // Child scrollHeight is only used for the zero-dimension early-bail check.
+  Object.defineProperty(childEl, 'scrollHeight', { configurable: true, get: () => naturalHeight })
+}
+
+describe('useTextResize', () => {
+  beforeEach(() => {
+    // Disable ResizeObserver so onMounted doesn't observe; we drive resizeText() directly.
+    global.ResizeObserver = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shrinks font when content height overflows', async () => {
+    const wrapper = mount(TestComponent, { attachTo: document.body })
+    await nextTick()
+    mockLayout(wrapper, { fieldWidth: 100, fieldHeight: 100, naturalWidth: 50, naturalHeight: 1000 })
+
+    wrapper.vm.resizeText()
+    expect(parseFloat(wrapper.vm.containerRef.style.fontSize)).toBeLessThanOrEqual(10)
+    wrapper.unmount()
+  })
+
+  it('shrinks font when content width overflows even if height fits', async () => {
+    const wrapper = mount(TestComponent, { attachTo: document.body })
+    await nextTick()
+    // Wide non-wrapping content. Without the width check, height alone would say
+    // 100% font fits (50 <= 100), but the text overflows sideways.
+    mockLayout(wrapper, { fieldWidth: 100, fieldHeight: 100, naturalWidth: 1000, naturalHeight: 50 })
+
+    wrapper.vm.resizeText()
+    expect(parseFloat(wrapper.vm.containerRef.style.fontSize)).toBeLessThanOrEqual(10)
+    wrapper.unmount()
+  })
+
+  it('grows font when content fits comfortably', async () => {
+    const wrapper = mount(TestComponent, { attachTo: document.body })
+    await nextTick()
+    mockLayout(wrapper, { fieldWidth: 100, fieldHeight: 100, naturalWidth: 1, naturalHeight: 1 })
+
+    wrapper.vm.resizeText()
+    expect(parseFloat(wrapper.vm.containerRef.style.fontSize)).toBeGreaterThan(1000)
+    wrapper.unmount()
+  })
+
+  it('bails when container has zero width', async () => {
+    const wrapper = mount(TestComponent, { attachTo: document.body })
+    await nextTick()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockLayout(wrapper, { fieldWidth: 0, fieldHeight: 100, naturalWidth: 50, naturalHeight: 50 })
+
+    wrapper.vm.resizeText()
+    expect(errorSpy).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- `useTextResize` only compared `scrollHeight` to `offsetHeight`, which works for wrapping text (RichText/ticker) where horizontal overflow becomes vertical, but misses non-wrapping text. Clock lines have `white-space: nowrap`, so a wide format (e.g. \`h:mm:ss a\`) overflows the time field sideways without ever growing taller — and the resize never triggered.
- Add `scrollWidth <= offsetWidth` to the binary-search fit condition.
- Add unit tests for the composable covering height-only overflow, width-only overflow, comfortable fit (grow), and the zero-dimension early-bail.

Fixes #1775.

## Test plan
- [x] \`yarn run vitest\` (122 frontend tests pass)
- [x] \`yarn run eslint\` clean
- [ ] Manually verify on a portrait screen with a small time field that the clock now shrinks to fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)