### PR TITLE
Scale graphics to fill their container

### DIFF
--- a/app/frontend/components/ConcertoGraphic.vue
+++ b/app/frontend/components/ConcertoGraphic.vue
@@ -1,16 +1,61 @@
 <script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
 defineProps({
   content: {type: Object, required: true},
   boxStyle: {type: String, required: false, default: ''},
 });
+
+const containerRef = ref(null)
+const imgRef = ref(null)
+let resizeObserver = null
+
+// Constrain the binding axis to 100% and let the image's intrinsic
+// aspect ratio drive the other dimension. The img element box ends up
+// equal to the rendered content rectangle, so a boxStyle border hugs
+// the image at any container size — including when the image has been
+// scaled up to fill a position larger than its native pixel dimensions.
+function fitImage() {
+  const container = containerRef.value
+  const img = imgRef.value
+  if (!container || !img || !img.naturalWidth || !img.naturalHeight) return
+  if (!container.clientWidth || !container.clientHeight) return
+
+  const containerRatio = container.clientWidth / container.clientHeight
+  const imageRatio = img.naturalWidth / img.naturalHeight
+
+  if (imageRatio > containerRatio) {
+    img.style.width = '100%'
+    img.style.height = 'auto'
+  } else {
+    img.style.width = 'auto'
+    img.style.height = '100%'
+  }
+}
+
+onMounted(() => {
+  if (window.ResizeObserver && containerRef.value) {
+    resizeObserver = new ResizeObserver(fitImage)
+    resizeObserver.observe(containerRef.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+})
 </script>
 
 <template>
-  <div class="graphic-container">
+  <div
+    ref="containerRef"
+    class="graphic-container"
+  >
     <img
+      ref="imgRef"
       class="graphic"
       :src="content.image"
       :style="boxStyle"
+      @load="fitImage"
     >
   </div>
 </template>
@@ -78,8 +123,8 @@ export function preload(content) {
 
   .graphic {
     display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
+    /* width and height are set in JS by fitImage() based on container
+       and image aspect ratios so the element box matches the rendered
+       content rectangle. */
   }
 </style>

--- a/app/frontend/components/ConcertoGraphic.vue
+++ b/app/frontend/components/ConcertoGraphic.vue
@@ -1,61 +1,16 @@
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
-
 defineProps({
   content: {type: Object, required: true},
   boxStyle: {type: String, required: false, default: ''},
 });
-
-const containerRef = ref(null)
-const imgRef = ref(null)
-let resizeObserver = null
-
-// Constrain the binding axis to 100% and let the image's intrinsic
-// aspect ratio drive the other dimension. The img element box ends up
-// equal to the rendered content rectangle, so a boxStyle border hugs
-// the image at any container size — including when the image has been
-// scaled up to fill a position larger than its native pixel dimensions.
-function fitImage() {
-  const container = containerRef.value
-  const img = imgRef.value
-  if (!container || !img || !img.naturalWidth || !img.naturalHeight) return
-  if (!container.clientWidth || !container.clientHeight) return
-
-  const containerRatio = container.clientWidth / container.clientHeight
-  const imageRatio = img.naturalWidth / img.naturalHeight
-
-  if (imageRatio > containerRatio) {
-    img.style.width = '100%'
-    img.style.height = 'auto'
-  } else {
-    img.style.width = 'auto'
-    img.style.height = '100%'
-  }
-}
-
-onMounted(() => {
-  if (window.ResizeObserver && containerRef.value) {
-    resizeObserver = new ResizeObserver(fitImage)
-    resizeObserver.observe(containerRef.value)
-  }
-})
-
-onBeforeUnmount(() => {
-  resizeObserver?.disconnect()
-})
 </script>
 
 <template>
-  <div
-    ref="containerRef"
-    class="graphic-container"
-  >
+  <div class="graphic-container">
     <img
-      ref="imgRef"
       class="graphic"
       :src="content.image"
       :style="boxStyle"
-      @load="fitImage"
     >
   </div>
 </template>
@@ -123,8 +78,8 @@ export function preload(content) {
 
   .graphic {
     display: block;
-    /* width and height are set in JS by fitImage() based on container
-       and image aspect ratios so the element box matches the rendered
-       content rectangle. */
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
   }
 </style>

--- a/app/frontend/components/ConcertoGraphic.vue
+++ b/app/frontend/components/ConcertoGraphic.vue
@@ -78,8 +78,8 @@ export function preload(content) {
 
   .graphic {
     display: block;
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
   }
 </style>

--- a/test/frontend/components/ConcertoGraphic.test.js
+++ b/test/frontend/components/ConcertoGraphic.test.js
@@ -16,40 +16,17 @@ describe('ConcertoGraphic', () => {
     expect(img.attributes('src')).toBe('image.jpg');
   })
 
-  // Drive the @load handler with a stubbed naturalWidth/naturalHeight and
-  // a known container size. The component should pick the binding axis
-  // and let the intrinsic ratio drive the other.
-  function fireLoad(wrapper, { containerWidth, containerHeight, naturalWidth, naturalHeight }) {
-    const container = wrapper.vm.containerRef
-    const img = wrapper.vm.imgRef
-    Object.defineProperty(container, 'clientWidth', { configurable: true, get: () => containerWidth })
-    Object.defineProperty(container, 'clientHeight', { configurable: true, get: () => containerHeight })
-    Object.defineProperty(img, 'naturalWidth', { configurable: true, get: () => naturalWidth })
-    Object.defineProperty(img, 'naturalHeight', { configurable: true, get: () => naturalHeight })
-    img.dispatchEvent(new Event('load'))
-  }
-
-  it('constrains width when the image is wider than the container', async () => {
+  it('scales the image to fill its container while preserving aspect ratio', () => {
     const wrapper = mount(ConcertoGraphic, {
       props: { content: { image: 'image.jpg' } },
       attachTo: document.body,
     });
-    fireLoad(wrapper, { containerWidth: 400, containerHeight: 400, naturalWidth: 1600, naturalHeight: 900 })
-    const img = wrapper.vm.imgRef
-    expect(img.style.width).toBe('100%')
-    expect(img.style.height).toBe('auto')
-    wrapper.unmount();
-  })
 
-  it('constrains height when the image is taller than the container', async () => {
-    const wrapper = mount(ConcertoGraphic, {
-      props: { content: { image: 'image.jpg' } },
-      attachTo: document.body,
-    });
-    fireLoad(wrapper, { containerWidth: 400, containerHeight: 400, naturalWidth: 600, naturalHeight: 800 })
-    const img = wrapper.vm.imgRef
-    expect(img.style.height).toBe('100%')
-    expect(img.style.width).toBe('auto')
+    const style = window.getComputedStyle(wrapper.get('.graphic').element);
+    expect(style.width).toBe('100%');
+    expect(style.height).toBe('100%');
+    expect(style.objectFit).toBe('contain');
+
     wrapper.unmount();
   })
 })

--- a/test/frontend/components/ConcertoGraphic.test.js
+++ b/test/frontend/components/ConcertoGraphic.test.js
@@ -16,17 +16,40 @@ describe('ConcertoGraphic', () => {
     expect(img.attributes('src')).toBe('image.jpg');
   })
 
-  it('scales the image to fill its container while preserving aspect ratio', () => {
+  // Drive the @load handler with a stubbed naturalWidth/naturalHeight and
+  // a known container size. The component should pick the binding axis
+  // and let the intrinsic ratio drive the other.
+  function fireLoad(wrapper, { containerWidth, containerHeight, naturalWidth, naturalHeight }) {
+    const container = wrapper.vm.containerRef
+    const img = wrapper.vm.imgRef
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: () => containerWidth })
+    Object.defineProperty(container, 'clientHeight', { configurable: true, get: () => containerHeight })
+    Object.defineProperty(img, 'naturalWidth', { configurable: true, get: () => naturalWidth })
+    Object.defineProperty(img, 'naturalHeight', { configurable: true, get: () => naturalHeight })
+    img.dispatchEvent(new Event('load'))
+  }
+
+  it('constrains width when the image is wider than the container', async () => {
     const wrapper = mount(ConcertoGraphic, {
       props: { content: { image: 'image.jpg' } },
       attachTo: document.body,
     });
+    fireLoad(wrapper, { containerWidth: 400, containerHeight: 400, naturalWidth: 1600, naturalHeight: 900 })
+    const img = wrapper.vm.imgRef
+    expect(img.style.width).toBe('100%')
+    expect(img.style.height).toBe('auto')
+    wrapper.unmount();
+  })
 
-    const style = window.getComputedStyle(wrapper.get('.graphic').element);
-    expect(style.width).toBe('100%');
-    expect(style.height).toBe('100%');
-    expect(style.objectFit).toBe('contain');
-
+  it('constrains height when the image is taller than the container', async () => {
+    const wrapper = mount(ConcertoGraphic, {
+      props: { content: { image: 'image.jpg' } },
+      attachTo: document.body,
+    });
+    fireLoad(wrapper, { containerWidth: 400, containerHeight: 400, naturalWidth: 600, naturalHeight: 800 })
+    const img = wrapper.vm.imgRef
+    expect(img.style.height).toBe('100%')
+    expect(img.style.width).toBe('auto')
     wrapper.unmount();
   })
 })

--- a/test/frontend/components/ConcertoGraphic.test.js
+++ b/test/frontend/components/ConcertoGraphic.test.js
@@ -15,6 +15,20 @@ describe('ConcertoGraphic', () => {
     expect(img.element.tagName).toBe('IMG');
     expect(img.attributes('src')).toBe('image.jpg');
   })
+
+  it('scales the image to fill its container while preserving aspect ratio', () => {
+    const wrapper = mount(ConcertoGraphic, {
+      props: { content: { image: 'image.jpg' } },
+      attachTo: document.body,
+    });
+
+    const style = window.getComputedStyle(wrapper.get('.graphic').element);
+    expect(style.width).toBe('100%');
+    expect(style.height).toBe('100%');
+    expect(style.objectFit).toBe('contain');
+
+    wrapper.unmount();
+  })
 })
 
 describe('ConcertoGraphic.preload', () => {


### PR DESCRIPTION
## Summary
- `ConcertoGraphic` used `max-width: 100%; max-height: 100%`, which clamps oversized images down but never grows undersized ones. A 1275px-tall PDF flyer therefore rendered at native pixel size on a 4K screen, leaving wide letterbox/pillarbox margins.
- Switching to `width: 100%; height: 100%` (paired with the existing `object-fit: contain`) makes the image scale up or down to fill the container while preserving aspect ratio. Mismatched aspect ratios still letterbox rather than crop.
- Added a test asserting the computed style of `.graphic`.

Fixes #1779.

## Trade-offs

- Low-resolution graphics on big screens will get upscaled and look softer. That's the explicit ask in the issue — preserving aspect ratio without crop means accepting some upscaling.
- A `boxStyle` border (the per-template border on the main field) now outlines the full field rectangle rather than hugging the image. This matches how the video components already behave (`ConcertoYoutubeVideo` et al. apply `boxStyle` to a `width: 100%; height: 100%` wrapper), so we're not introducing a new inconsistency, just propagating the existing one to graphics. The proper fix is to solve sizing & borders once at the field/composable level for any content type with an aspect ratio — tracked in #1781.

We initially tried two patches that hugged the image (pure-CSS aspect-ratio and a JS `fitImage()` + ResizeObserver). The CSS one stretched images under `max-height` clamping; the JS one worked but parked complexity in a single component while leaving videos unchanged. Both are documented in #1781 for reference.

## Test plan
- [x] `yarn run vitest` (123 tests, 1 skipped)
- [x] `yarn run eslint` clean
- [x] Manually verified small graphics now fill large positions on the dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
