### PR TITLE
Make portrait graphics taller on graphics#show

### DIFF
--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -1,7 +1,7 @@
 class Graphic < Content
   has_one_attached :image do |attachable|
     attachable.variant :grid, resize_to_limit: [ nil, 400 ]
-    attachable.variant :show, resize_to_limit: [ 1000, 1000 ]
+    attachable.variant :preview, resize_to_limit: [ 1000, 1000 ]
   end
 
   store_accessor :config, :conversion_error

--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -1,6 +1,7 @@
 class Graphic < Content
   has_one_attached :image do |attachable|
     attachable.variant :grid, resize_to_limit: [ nil, 400 ]
+    attachable.variant :show, resize_to_limit: [ 1000, 1000 ]
   end
 
   store_accessor :config, :conversion_error

--- a/app/views/graphics/_graphic.html.erb
+++ b/app/views/graphics/_graphic.html.erb
@@ -25,7 +25,7 @@
       <% elsif graphic.image.attached? && graphic.image.variable? %>
         <div class="flex justify-center">
           <%= link_to graphic.image, class: "block" do %>
-            <%= image_tag graphic.image.variant(:show),
+            <%= image_tag graphic.image.variant(:preview),
                 class: "max-w-full max-h-[80vh] h-auto w-auto rounded-lg shadow-sm border border-neutral-200" %>
           <% end %>
         </div>

--- a/app/views/graphics/_graphic.html.erb
+++ b/app/views/graphics/_graphic.html.erb
@@ -25,8 +25,8 @@
       <% elsif graphic.image.attached? && graphic.image.variable? %>
         <div class="flex justify-center">
           <%= link_to graphic.image, class: "block" do %>
-            <%= image_tag graphic.image.variant(:grid),
-                class: "max-w-full h-auto rounded-lg shadow-sm border border-neutral-200" %>
+            <%= image_tag graphic.image.variant(:show),
+                class: "max-w-full max-h-[80vh] h-auto w-auto rounded-lg shadow-sm border border-neutral-200" %>
           <% end %>
         </div>
       <% elsif graphic.image.attached? %>

--- a/app/views/graphics/_graphic.html.erb
+++ b/app/views/graphics/_graphic.html.erb
@@ -26,6 +26,7 @@
         <div class="flex justify-center">
           <%= link_to graphic.image, class: "block" do %>
             <%= image_tag graphic.image.variant(:preview),
+                alt: graphic.name,
                 class: "max-w-full max-h-[80vh] h-auto w-auto rounded-lg shadow-sm border border-neutral-200" %>
           <% end %>
         </div>


### PR DESCRIPTION
## Summary
- Adds a larger `:show` ActiveStorage variant for graphics (resize_to_limit 1000x1000) so portrait and landscape images get similar visual weight on the show page.
- Updates `graphics#show` to use the new variant and caps the rendered height with `max-h-[80vh]` so tall portraits don't dominate the viewport.

Fixes #1778.

## Test plan
- [x] `bin/rails test test/models/graphic_test.rb test/controllers/graphics_controller_test.rb`
- [ ] Manually verify a portrait graphic renders taller on `/graphics/:id` and a landscape graphic still fits within the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)