### PR TITLE
Render videos in portrait positions

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -49,7 +49,8 @@ class Video < Content
   # letterboxes to fit. A tighter 2x-3x bound is more shape-aware but rejects
   # useful cross-orientation cases.
   def should_render_in?(position)
-    ratio = effective_aspect_ratio_value
+    width, height = effective_aspect_ratio.split("/").map(&:to_f)
+    ratio = width / height
     (position.aspect_ratio / 4.0) <= ratio && ratio <= (position.aspect_ratio * 4.0)
   end
 
@@ -111,11 +112,6 @@ class Video < Content
   end
 
   private
-
-  def effective_aspect_ratio_value
-    width, height = effective_aspect_ratio.split("/").map(&:to_f)
-    width / height
-  end
 
   # Memoized helper to fetch Vimeo oEmbed data once per request
   def vimeo_oembed_data

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -42,12 +42,15 @@ class Video < Content
     end
   end
 
-  # For now, videos should only be rendered in positions that are roughly
-  # somewhere in the [4:3 - 16:9] range, with a large buffer.
+  # Allow videos in positions whose aspect ratio is within 4x of the video's
+  # own, mirroring Graphic#should_render_in?. 4x keeps tickers and other
+  # extreme banner shapes out while still allowing cross-orientation placement
+  # (e.g. a 9:16 short in a 16:9 main), which is OK because the player
+  # letterboxes to fit. A tighter 2x-3x bound is more shape-aware but rejects
+  # useful cross-orientation cases.
   def should_render_in?(position)
-    # I don't really know what these numbers should be, there
-    # is room for tuning.
-    (0.25 < position.aspect_ratio && position.aspect_ratio <= 1)
+    ratio = effective_aspect_ratio_value
+    (position.aspect_ratio / 4.0) <= ratio && ratio <= (position.aspect_ratio * 4.0)
   end
 
   def video_id
@@ -108,6 +111,11 @@ class Video < Content
   end
 
   private
+
+  def effective_aspect_ratio_value
+    width, height = effective_aspect_ratio.split("/").map(&:to_f)
+    width / height
+  end
 
   # Memoized helper to fetch Vimeo oEmbed data once per request
   def vimeo_oembed_data

--- a/test/models/video_test.rb
+++ b/test/models/video_test.rb
@@ -20,6 +20,16 @@ class VideoTest < ActiveSupport::TestCase
     assert_not @tiktok_video.should_render_in?(positions(:two_ticker)), positions(:two_ticker).aspect_ratio
   end
 
+  test "renders portrait videos in tall portrait positions" do
+    assert @youtube_short.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
+    assert @tiktok_video.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
+  end
+
+  test "rejects landscape videos in tall portrait positions" do
+    assert_not @youtube_video.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
+    assert_not @vimeo_video.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
+  end
+
   test "extracts video id from youtube url" do
     assert_equal "eT4OAYjzV-s", @youtube_video.video_id
   end


### PR DESCRIPTION
## Summary
- `Video#should_render_in?` was hardcoded to `(0.25 < ar <= 1)`, which ignored the video's own aspect ratio. It rejected anything wider than square in template-normalized coords and didn't differentiate between a 16:9 widescreen and a 9:16 short.
- Mirror the content-aware pattern from `Graphic#should_render_in?`: compare the position's aspect ratio to the video's `effective_aspect_ratio` within a configurable tolerance (4×).
- A 9:16 short now renders happily in tall sidebars; landscape videos still get rejected from extreme tickers and very narrow portrait positions; the player continues to letterbox cross-orientation cases.

## Tolerance choice (4×)
We considered three multipliers; recording for future tuning:

| Multiplier | 16:9 in `two_graphic` (ar 0.74) | 9:16 in 16:9 main (ar 1.78) | Tickers (ar 7.5) |
|---|---|---|---|
| 2× | rejected (regresses existing test) | rejected | rejected |
| 3× | fits | rejected (just barely) | rejected |
| **4×** | **fits** | **fits** | **rejected (just barely)** |

4× wins for now because it allows full cross-orientation placement (the issue specifically calls out wanting 9:16 shorts to play in landscape mains and vice versa) while still excluding tickers. The downside is little headroom — anything wider than a ticker would slip through. If we pick up wide banner positions later we may want to tighten back to 3× and add an explicit position-shape check.

Fixes #1784.

## Test plan
- [x] `bin/rails test test/models/video_test.rb`
- [x] `bin/rails test` (full suite)
- [x] `bundle exec rubocop app/models/video.rb test/models/video_test.rb`
- [ ] Manually verify a 9:16 video plays in a portrait main and a 16:9 video plays in a portrait main with letterboxing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)