### PR TITLE
Fold search into header row on content and feed index pages

### DIFF
--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -19,10 +19,10 @@
           end %>
     </p>
   </div>
-  
-  <div class="flex flex-col sm:flex-row lg:items-center gap-3 lg:gap-4">
+
+  <div class="flex flex-col gap-3">
     <!-- Content Scope Toggle -->
-    <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg">
+    <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg self-start lg:self-auto">
       <%= link_to contents_path(scope: 'active'),
           class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'active' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
         Active
@@ -30,7 +30,7 @@
           <%= Content.approved.active.count %>
         </span>
       <% end %>
-      
+
       <%= link_to contents_path(scope: 'upcoming'),
           class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'upcoming' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
         Upcoming
@@ -38,7 +38,7 @@
           <%= Content.approved.upcoming.count %>
         </span>
       <% end %>
-      
+
       <%= link_to contents_path(scope: 'expired'),
           class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'expired' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
         Expired
@@ -47,25 +47,28 @@
         </span>
       <% end %>
     </div>
-    
-    <% if policy(Content).create? %>
-      <%= link_to new_content_path, class: "btn-primary btn-md whitespace-nowrap self-start sm:self-auto" do %>
-        <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
-        New Content
+
+    <!-- Search + New Content (stacked on mobile, side-by-side on sm+) -->
+    <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+      <%= form_with url: contents_path, method: :get, local: true do |f| %>
+        <%= hidden_field_tag :scope, @scope %>
+        <div class="relative">
+          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
+          </div>
+          <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full sm:w-56 text-sm" %>
+        </div>
       <% end %>
-    <% end %>
+
+      <% if policy(Content).create? %>
+        <%= link_to new_content_path, class: "btn-primary btn-md whitespace-nowrap self-start sm:self-auto" do %>
+          <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
+          New Content
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>
-
-<%= form_with url: contents_path, method: :get, local: true, class: "mb-4" do |f| %>
-  <%= hidden_field_tag :scope, @scope %>
-  <div class="relative max-w-md">
-    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-      <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
-    </div>
-    <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full text-sm" %>
-  </div>
-<% end %>
 
 <% if @query.present? %>
   <p class="text-body text-neutral-700 mb-4">

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -20,9 +20,19 @@
     </p>
   </div>
 
-  <div class="flex flex-col gap-3">
-    <!-- Content Scope Toggle -->
-    <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg self-start lg:self-auto">
+  <!-- Search + Scope Toggle + New Content (stacked on mobile, single row on sm+) -->
+  <div class="flex flex-col sm:flex-row sm:items-center flex-wrap gap-3">
+    <%= form_with url: contents_path, method: :get, local: true do |f| %>
+      <%= hidden_field_tag :scope, @scope %>
+      <div class="relative">
+        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
+        </div>
+        <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full sm:w-48 text-sm" %>
+      </div>
+    <% end %>
+
+    <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg self-start sm:self-auto">
       <%= link_to contents_path(scope: 'active'),
           class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'active' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
         Active
@@ -48,25 +58,12 @@
       <% end %>
     </div>
 
-    <!-- Search + New Content (stacked on mobile, side-by-side on sm+) -->
-    <div class="flex flex-col sm:flex-row sm:items-center gap-3">
-      <%= form_with url: contents_path, method: :get, local: true do |f| %>
-        <%= hidden_field_tag :scope, @scope %>
-        <div class="relative">
-          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
-          </div>
-          <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full sm:w-56 text-sm" %>
-        </div>
+    <% if policy(Content).create? %>
+      <%= link_to new_content_path, class: "btn-primary btn-md whitespace-nowrap self-start sm:self-auto" do %>
+        <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
+        New Content
       <% end %>
-
-      <% if policy(Content).create? %>
-        <%= link_to new_content_path, class: "btn-primary btn-md whitespace-nowrap self-start sm:self-auto" do %>
-          <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
-          New Content
-        <% end %>
-      <% end %>
-    </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -37,7 +37,7 @@
       <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
         <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
       </div>
-      <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full sm:w-56 text-sm" %>
+      <%= f.search_field :q, value: @query, placeholder: "Search content…", aria: { label: "Search content" }, class: "frm-input pl-10 w-full sm:w-56 text-sm" %>
     </div>
   <% end %>
 

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -1,6 +1,7 @@
 <%= page_title "Content" %>
 
-<div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 mb-6">
+<!-- Title row: identity + primary CTA only -->
+<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-3">
   <div>
     <h1 class="text-h2 text-neutral-900">
       <%= case @scope
@@ -20,49 +21,49 @@
     </p>
   </div>
 
-  <!-- Search + Scope Toggle + New Content (stacked on mobile, single row on sm+) -->
-  <div class="flex flex-col sm:flex-row sm:items-center flex-wrap gap-3">
-    <%= form_with url: contents_path, method: :get, local: true do |f| %>
-      <%= hidden_field_tag :scope, @scope %>
-      <div class="relative">
-        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-          <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
-        </div>
-        <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full sm:w-48 text-sm" %>
+  <% if policy(Content).create? %>
+    <%= link_to new_content_path, class: "btn-primary btn-md whitespace-nowrap self-start sm:self-auto" do %>
+      <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
+      New Content
+    <% end %>
+  <% end %>
+</div>
+
+<!-- Filter bar: search + scope toggle -->
+<div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-6">
+  <%= form_with url: contents_path, method: :get, local: true do |f| %>
+    <%= hidden_field_tag :scope, @scope %>
+    <div class="relative">
+      <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
       </div>
+      <%= f.search_field :q, value: @query, placeholder: "Search content…", class: "frm-input pl-10 w-full sm:w-56 text-sm" %>
+    </div>
+  <% end %>
+
+  <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg self-start sm:self-auto">
+    <%= link_to contents_path(scope: 'active'),
+        class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'active' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+      Active
+      <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-success text-white rounded-full">
+        <%= Content.approved.active.count %>
+      </span>
     <% end %>
 
-    <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg self-start sm:self-auto">
-      <%= link_to contents_path(scope: 'active'),
-          class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'active' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
-        Active
-        <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-success text-white rounded-full">
-          <%= Content.approved.active.count %>
-        </span>
-      <% end %>
+    <%= link_to contents_path(scope: 'upcoming'),
+        class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'upcoming' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+      Upcoming
+      <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-warning text-white rounded-full">
+        <%= Content.approved.upcoming.count %>
+      </span>
+    <% end %>
 
-      <%= link_to contents_path(scope: 'upcoming'),
-          class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'upcoming' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
-        Upcoming
-        <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-warning text-white rounded-full">
-          <%= Content.approved.upcoming.count %>
-        </span>
-      <% end %>
-
-      <%= link_to contents_path(scope: 'expired'),
-          class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'expired' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
-        Expired
-        <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-error text-white rounded-full">
-          <%= Content.approved.expired.count %>
-        </span>
-      <% end %>
-    </div>
-
-    <% if policy(Content).create? %>
-      <%= link_to new_content_path, class: "btn-primary btn-md whitespace-nowrap self-start sm:self-auto" do %>
-        <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
-        New Content
-      <% end %>
+    <%= link_to contents_path(scope: 'expired'),
+        class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'expired' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+      Expired
+      <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-error text-white rounded-full">
+        <%= Content.approved.expired.count %>
+      </span>
     <% end %>
   </div>
 </div>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -1,11 +1,20 @@
 <%= page_title "Feeds" %>
 
-<div class="flex items-center justify-between mb-6">
+<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
   <div>
     <h1 class="text-h2 text-neutral-900">All Feeds</h1>
     <p class="text-body text-neutral-700 mt-1">Organize content into feeds for your digital displays</p>
   </div>
-  <div class="flex space-x-3">
+  <div class="flex flex-col sm:flex-row sm:items-center flex-wrap gap-3">
+    <%= form_with url: feeds_path, method: :get, local: true do |f| %>
+      <div class="relative">
+        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
+        </div>
+        <%= f.search_field :q, value: @query, placeholder: "Search feeds…", class: "frm-input pl-10 w-full sm:w-48 text-sm" %>
+      </div>
+    <% end %>
+
     <% if policy(Feed.new).new? %>
       <%= link_to new_feed_path, class: "btn-primary btn-md whitespace-nowrap" do %>
         <%= heroicon('plus', class: 'w-4 h-4 mr-2') %>
@@ -29,15 +38,6 @@
   </div>
 </div>
 
-<%= form_with url: feeds_path, method: :get, local: true, class: "mb-4" do |f| %>
-  <div class="relative max-w-md">
-    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-      <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
-    </div>
-    <%= f.search_field :q, value: @query, placeholder: "Search feeds…", class: "frm-input pl-10 w-full text-sm" %>
-  </div>
-<% end %>
-
 <% if @query.present? %>
   <p class="text-body text-neutral-700 mb-4">
     <%= pluralize(@feeds.size, "match") %> for "<%= @query %>"
@@ -54,13 +54,13 @@
             <h3 class="text-h3 text-neutral-900 mb-2">
               <%= link_to feed.name, feed, class: "hover:text-brand transition-colors" %>
             </h3>
-            
+
             <% if feed.description.present? %>
               <p class="text-body text-neutral-700 mb-4">
                 <%= feed.description %>
               </p>
             <% end %>
-            
+
             <div class="flex items-center space-x-4 text-caption text-neutral-500">
               <div class="flex items-center">
                 <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -68,7 +68,7 @@
                 </svg>
                 <%= pluralize(feed.content.count, 'item') %>
               </div>
-              
+
               <div class="flex items-center">
                 <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -77,7 +77,7 @@
               </div>
             </div>
           </div>
-          
+
           <div class="ml-4">
             <%= link_to feed, class: "btn-secondary btn-sm" do %>
               <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -91,7 +91,7 @@
       </div>
     </div>
   <% end %>
-  
+
   <% if @feeds.empty? %>
     <div class="text-center py-12">
       <svg class="mx-auto h-12 w-12 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -1,10 +1,12 @@
 <%= page_title "Feeds" %>
 
+<!-- Title row: search sits between identity and action buttons -->
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
   <div>
     <h1 class="text-h2 text-neutral-900">All Feeds</h1>
     <p class="text-body text-neutral-700 mt-1">Organize content into feeds for your digital displays</p>
   </div>
+
   <div class="flex flex-col sm:flex-row sm:items-center flex-wrap gap-3">
     <%= form_with url: feeds_path, method: :get, local: true do |f| %>
       <div class="relative">

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -13,7 +13,7 @@
         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <%= heroicon "magnifying-glass", class: "h-5 w-5 text-neutral-500" %>
         </div>
-        <%= f.search_field :q, value: @query, placeholder: "Search feeds…", class: "frm-input pl-10 w-full sm:w-48 text-sm" %>
+        <%= f.search_field :q, value: @query, placeholder: "Search feeds…", aria: { label: "Search feeds" }, class: "frm-input pl-10 w-full sm:w-48 text-sm" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
## Summary

- Removes the standalone search form row that appeared between the page header and the content/feed list on both index pages
- Search input now lives inline with the scope toggle + action buttons in the existing header row, saving ~60px of vertical space
- On mobile, the search stacks cleanly below the scope toggle (content) or title (feeds) using responsive flex classes (`flex-col sm:flex-row`)

## Test plan

- [x] Visit `/contents` on desktop — search appears inline next to "New Content" button, below scope toggle
- [x] Visit `/feeds` on desktop — search appears inline with the New Feed / New RSS / New Remote buttons
- [x] Resize to mobile width — search stacks vertically, no overflow or clipped elements
- [x] Search with a query on both pages — results count + Clear link still appears
- [x] Scope toggle on content page still filters correctly when searching
- [x] All controller tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)