### PR TITLE
Fix image upload rejection in production (#1796)

### DIFF
--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -6,8 +6,6 @@ class Graphic < Content
 
   store_accessor :config, :conversion_error
 
-  SUPPORTED_CONTENT_TYPES = (ActiveStorage.variable_content_types + [ "application/pdf" ]).freeze
-
   # URL Helpers are needed so we can generate a URL to the image in the JSON.
   include Rails.application.routes.url_helpers
 
@@ -79,7 +77,15 @@ class Graphic < Content
   end
 
   def image_content_type_supported
-    return if SUPPORTED_CONTENT_TYPES.include?(image.content_type)
+    return if self.class.supported_content_types.include?(image.content_type)
     errors.add(:image, "type #{image.content_type} is not supported")
+  end
+
+  # Built lazily so ActiveStorage.variable_content_types has been populated by
+  # its after_initialize hook before we read it (in production with eager
+  # loading, a constant here would be evaluated before that hook runs, leaving
+  # the list empty and rejecting every upload except PDF).
+  def self.supported_content_types
+    ActiveStorage.variable_content_types + [ "application/pdf" ]
   end
 end

--- a/test/controllers/graphics_controller_test.rb
+++ b/test/controllers/graphics_controller_test.rb
@@ -91,6 +91,30 @@ class GraphicsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to contents_url
   end
 
+  test "should accept PNG upload on create" do
+    sign_in @user
+    assert_difference("Graphic.count") do
+      post graphics_url, params: { graphic: {
+        name: "PNG upload", duration: 10,
+        image: fixture_file_upload("template_portrait.png", "image/png")
+      } }
+    end
+    assert_redirected_to graphic_url(Graphic.last)
+    assert_equal "image/png", Graphic.last.image.content_type
+  end
+
+  test "should accept JPEG upload on create" do
+    sign_in @user
+    assert_difference("Graphic.count") do
+      post graphics_url, params: { graphic: {
+        name: "JPG upload", duration: 10,
+        image: fixture_file_upload("one.jpg", "image/jpeg")
+      } }
+    end
+    assert_redirected_to graphic_url(Graphic.last)
+    assert_equal "image/jpeg", Graphic.last.image.content_type
+  end
+
   test "should reject unsupported file type on create" do
     sign_in @user
     assert_no_difference("Graphic.count") do

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -28,8 +28,18 @@ class GraphicTest < ActiveSupport::TestCase
     assert_not portrait.should_render_in?(positions(:two_ticker))
   end
 
+  test "supported_content_types includes common web image formats" do
+    # Regression: previously this list was frozen at class-load time before
+    # ActiveStorage's after_initialize populated variable_content_types, so in
+    # production the list collapsed to ["application/pdf"] and every image
+    # upload was rejected.
+    %w[image/png image/jpeg image/gif image/webp].each do |type|
+      assert_includes Graphic.supported_content_types, type
+    end
+  end
+
   test "accepts supported image content types" do
-    Graphic::SUPPORTED_CONTENT_TYPES.excluding("application/pdf").each do |content_type|
+    Graphic.supported_content_types.excluding("application/pdf").each do |content_type|
       graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
       graphic.image.attach(io: StringIO.new("data"), filename: "test", content_type: content_type)
       graphic.valid?


### PR DESCRIPTION
## Summary
- `Graphic::SUPPORTED_CONTENT_TYPES` read `ActiveStorage.variable_content_types` at class-body load time. In production with eager loading, that runs during `:eager_load!` — before `:run_after_initialize_callbacks` populates the list. The constant collapsed to `["application/pdf"]` and every PNG/JPEG upload was rejected. Dev/test (lazy loading) read the value after init, so the bug only surfaced in production. Reported in #1796 and confirmed on demo.concerto-signage.org.
- Replace the constant with `Graphic.supported_content_types` (class method) so the read happens at validation time.
- Add the missing tests that should have caught this:
  - **Model regression test** asserting the supported list includes common web image MIME types. The previous `accepts supported image content types` test iterated the constant and silently passed zero assertions when the list was empty.
  - **Controller happy-path tests** for PNG and JPEG uploads. The only image-upload controller test exercised the rejection path (`zip → 422`), which is how this slipped past CI.

Fixes #1796.

## Test plan
- [x] `bin/rails test test/models/graphic_test.rb test/controllers/graphics_controller_test.rb` — all green
- [x] `bin/rails test` — full suite, 972 runs, 0 failures
- [x] `bin/rails rubocop` on changed files — clean
- [x] Verified `RAILS_ENV=production bin/rails runner 'puts Graphic.supported_content_types'` now returns the full list (previously `["application/pdf"]`)
- [x] Verified `CI=true bin/rails runner -e test 'puts Graphic::SUPPORTED_CONTENT_TYPES'` on the old code reproduces `["application/pdf"]`, confirming the new model regression test would catch this in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)