### PR TITLE
Collapse large feed groups on content index page

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -21,7 +21,12 @@ class ContentsController < ApplicationController
 
     contents_scope = contents_scope.where(id: Search.matching_ids(@query, Content)) if @query.present?
 
-    @contents = policy_scope(contents_scope)
+    @contents = policy_scope(contents_scope).includes(:feeds)
+
+    feed_buckets = @contents.group_by { |c| c.feeds.find { |f| f.is_a?(RssFeed) || f.is_a?(RemoteFeed) } }
+    @feed_groups = feed_buckets.select { |feed, items| feed.present? && items.size > 3 }
+    collapsed_ids = @feed_groups.values.flatten.map(&:id).to_set
+    @primary_contents = @contents.reject { |c| collapsed_ids.include?(c.id) }
   end
 
   # GET /contents/new

--- a/app/views/contents/_feed_group.html.erb
+++ b/app/views/contents/_feed_group.html.erb
@@ -1,0 +1,33 @@
+<details class="mt-6 bg-white rounded-lg border border-neutral-200 shadow-sm">
+  <summary class="px-4 py-3 border-b border-neutral-200 cursor-pointer hover:bg-neutral-50 transition-colors flex items-center justify-between">
+    <div>
+      <span class="text-h3 text-neutral-900"><%= feed.name %></span>
+      <span class="text-caption text-neutral-500 ml-2"><%= pluralize(contents.length, "item") %></span>
+    </div>
+    <span class="text-caption text-brand">Expand to view</span>
+  </summary>
+  <div class="p-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <% contents.each do |content| %>
+        <%= link_to content, class: "group block" do %>
+          <div class="card hover:shadow-md transition-shadow duration-200">
+            <div class="card-body">
+              <div class="bg-neutral-100 rounded-lg mb-4 flex justify-center min-h-[200px] max-h-[400px] overflow-hidden">
+                <%= render partial: to_grid_partial_path(content), locals: {content: content} %>
+              </div>
+              <div class="space-y-2">
+                <h3 class="text-h4 text-neutral-900 group-hover:text-brand transition-colors">
+                  <%= content.name.presence || "Untitled Content" %>
+                </h3>
+                <div class="flex items-center justify-between text-caption text-neutral-500">
+                  <span class="capitalize"><%= content.class.name.downcase %></span>
+                  <span><%= time_ago_in_words(content.updated_at) %> ago</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</details>

--- a/app/views/contents/_grid.html.erb
+++ b/app/views/contents/_grid.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   <% end %>
   
-  <% if contents.empty? %>
+  <% if contents.empty? && local_assigns.fetch(:show_empty, true) %>
     <div class="col-span-full">
       <div class="text-center py-12">
         <%= heroicon("document-add", class: "mx-auto h-12 w-12 text-neutral-400") %>

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -75,4 +75,8 @@
   </p>
 <% end %>
 
-<%= render partial: "grid", locals: {contents: @contents} %>
+<%= render partial: "grid", locals: {contents: @primary_contents, show_empty: @contents.empty?} %>
+
+<% @feed_groups.each do |feed, feed_contents| %>
+  <%= render partial: "feed_group", locals: {feed: feed, contents: feed_contents} %>
+<% end %>

--- a/test/controllers/contents_controller_test.rb
+++ b/test/controllers/contents_controller_test.rb
@@ -79,4 +79,17 @@ class ContentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href^='/videos/']", count: 0
     assert_select "a[href^='/rich_texts/']", count: 0
   end
+
+  test "index renders collapsed feed group section for rss feed with more than 3 items" do
+    get contents_url
+    assert_response :success
+    assert_select "details summary", text: /#{rss_feeds(:yahoo_rssfeed).name}/
+  end
+
+  test "index places large rss feed content inside a details element" do
+    get contents_url
+    assert_response :success
+    assert_select "details a[href='#{rich_text_path(rich_texts(:rss_item_1))}']", count: 1
+    assert_select "details a[href='#{rich_text_path(rich_texts(:rss_item_4))}']", count: 1
+  end
 end

--- a/test/fixtures/rich_texts.yml
+++ b/test/fixtures/rich_texts.yml
@@ -76,3 +76,36 @@ upcoming_richtext_no_end:
   text: "This content will be active later"
   config: {'render_as': 'plaintext'}
   user: admin
+
+# Feed group threshold testing: 4 items submitted to yahoo_rssfeed (an RssFeed)
+rss_item_1:
+  type: RichText
+  name: "RSS Article 1"
+  duration: 30
+  text: "RSS feed content item 1"
+  config: {'render_as': 'plaintext'}
+  user: admin
+
+rss_item_2:
+  type: RichText
+  name: "RSS Article 2"
+  duration: 30
+  text: "RSS feed content item 2"
+  config: {'render_as': 'plaintext'}
+  user: admin
+
+rss_item_3:
+  type: RichText
+  name: "RSS Article 3"
+  duration: 30
+  text: "RSS feed content item 3"
+  config: {'render_as': 'plaintext'}
+  user: admin
+
+rss_item_4:
+  type: RichText
+  name: "RSS Article 4"
+  duration: 30
+  text: "RSS feed content item 4"
+  config: {'render_as': 'plaintext'}
+  user: admin

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -65,3 +65,24 @@ rejected_submission:
   feed: one
   moderation_status: rejected
   moderation_reason: Not appropriate for this feed
+
+# Feed group threshold testing: 4 items in yahoo_rssfeed (RssFeed > 3 triggers collapse)
+rss_item_sub_1:
+  content: rss_item_1
+  feed: yahoo_rssfeed
+  moderation_status: approved
+
+rss_item_sub_2:
+  content: rss_item_2
+  feed: yahoo_rssfeed
+  moderation_status: approved
+
+rss_item_sub_3:
+  content: rss_item_3
+  feed: yahoo_rssfeed
+  moderation_status: approved
+
+rss_item_sub_4:
+  content: rss_item_4
+  feed: yahoo_rssfeed
+  moderation_status: approved


### PR DESCRIPTION
## Summary

Closes #1720.

- When an RSS or Remote feed contributes **more than 3 content items**, those items are grouped into a collapsible `<details>` section at the bottom of the content index page instead of flooding the main grid
- User-submitted content and content from small feeds (≤ 3 items) remains in the primary grid unchanged
- The section starts closed by default, showing the feed name and item count; users can expand it to browse the feed content
- Uses the native HTML `<details>`/`<summary>` elements (no JavaScript required), consistent with the existing pattern in the screen settings form

## Test plan

- [ ] Add a Remote or RSS feed with 4+ approved active content items and confirm they disappear from the main grid and appear in a collapsed section
- [ ] Confirm feeds with ≤ 3 items still show in the main grid
- [ ] Confirm user-submitted content is unaffected
- [ ] Confirm expanding the section reveals all feed content with working links
- [ ] `bin/rails test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)