### PR TITLE
Surface uploader's content regardless of moderation state

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -10,23 +10,8 @@ class ContentsController < ApplicationController
     @scope = "active" if @scope == "mine" && !user_signed_in?
     @query = params[:q].to_s.strip
 
-    contents_scope = case @scope
-    when "active"   then Content.active
-    when "upcoming" then Content.upcoming
-    when "expired"  then Content.expired
-    when "mine"     then Content.where(user_id: current_user.id)
-    end
-
-    if @query.present?
-      contents_scope = if @scope == "mine"
-        # Mine includes unapproved content which the search corpus excludes,
-        # so fall back to a direct name match against the user's own uploads.
-        like = "%#{ActiveRecord::Base.sanitize_sql_like(@query)}%"
-        contents_scope.where("name LIKE ? COLLATE NOCASE", like)
-      else
-        contents_scope.where(id: Search.matching_ids(@query, Content))
-      end
-    end
+    contents_scope = base_content_scope
+    contents_scope = narrow_by_query(contents_scope) if @query.present?
 
     @contents = policy_scope(contents_scope).includes(:submissions)
   end
@@ -35,5 +20,27 @@ class ContentsController < ApplicationController
   def new
     @content = Content.new
     authorize @content
+  end
+
+  private
+
+  def base_content_scope
+    case @scope
+    when "upcoming" then Content.upcoming
+    when "expired"  then Content.expired
+    when "mine"     then current_user.contents
+    else                 Content.active
+    end
+  end
+
+  # Mine surfaces pending/rejected/unsubmitted uploads, which the search
+  # corpus excludes — so fall back to a direct name match on the user's
+  # own content for that scope.
+  def narrow_by_query(scope)
+    if @scope == "mine"
+      scope.with_name_matching(@query)
+    else
+      scope.where(id: Search.matching_ids(@query, Content))
+    end
   end
 end

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -5,23 +5,30 @@ class ContentsController < ApplicationController
 
   # GET /contents or /contents.json
   def index
-    @scope = params[:scope] || "active"
+    @scope = params[:scope].presence_in(%w[active upcoming expired mine]) || "active"
+    # "mine" is meaningless without an authenticated owner; fall back to active.
+    @scope = "active" if @scope == "mine" && !user_signed_in?
     @query = params[:q].to_s.strip
 
     contents_scope = case @scope
-    when "active"
-                  Content.active
-    when "upcoming"
-                  Content.upcoming
-    when "expired"
-                  Content.expired
-    else
-                  Content.active
+    when "active"   then Content.active
+    when "upcoming" then Content.upcoming
+    when "expired"  then Content.expired
+    when "mine"     then Content.where(user_id: current_user.id)
     end
 
-    contents_scope = contents_scope.where(id: Search.matching_ids(@query, Content)) if @query.present?
+    if @query.present?
+      contents_scope = if @scope == "mine"
+        # Mine includes unapproved content which the search corpus excludes,
+        # so fall back to a direct name match against the user's own uploads.
+        like = "%#{ActiveRecord::Base.sanitize_sql_like(@query)}%"
+        contents_scope.where("name LIKE ? COLLATE NOCASE", like)
+      else
+        contents_scope.where(id: Search.matching_ids(@query, Content))
+      end
+    end
 
-    @contents = policy_scope(contents_scope)
+    @contents = policy_scope(contents_scope).includes(:submissions)
   end
 
   # GET /contents/new

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -19,8 +19,13 @@ class FeedsController < ApplicationController
   def show
     authorize @feed
     @status = params[:status] || "approved"
-    # Non-moderators always see approved only
-    @status = "approved" unless policy(@feed).edit? && Submission.moderation_statuses.keys.include?(@status)
+
+    # Approved is public. Moderators get pending/rejected. Any signed-in user
+    # can pick "mine" to see their own submissions across moderation statuses.
+    allowed = [ "approved" ]
+    allowed += Submission.moderation_statuses.keys if policy(@feed).edit?
+    allowed << "mine" if user_signed_in?
+    @status = "approved" unless allowed.include?(@status)
 
     @scope = params[:scope] || "active"
     @scope = "active" unless %w[active upcoming expired].include?(@scope)

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -29,6 +29,8 @@ class FeedsController < ApplicationController
 
     @scope = params[:scope] || "active"
     @scope = "active" unless %w[active upcoming expired].include?(@scope)
+
+    @submissions = submissions_for_status unless @status == "approved"
   end
 
   # GET /feeds/new
@@ -92,6 +94,17 @@ class FeedsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_feed
       @feed = Feed.find(params[:id])
+    end
+
+    def submissions_for_status
+      base = @feed.submissions.includes(content: :user)
+      if @status == "mine"
+        base.joins(:content)
+            .where(content: { user_id: current_user.id })
+            .order(created_at: :desc)
+      else
+        base.where(moderation_status: @status)
+      end
     end
 
     # Redirects to the appropriate STI controller if the feed is not of the base Feed class.

--- a/app/helpers/contents_helper.rb
+++ b/app/helpers/contents_helper.rb
@@ -6,6 +6,22 @@ module ContentsHelper
         "#{ActiveSupport::Inflector.tableize(content.class.name)}/grid"
     end
 
+    # Returns an HTML badge for the given content's moderation state, or nil
+    # when the content is fully approved (no badge needed — the default case).
+    MODERATION_BADGE_STYLES = {
+        pending:     { label: "Pending",     classes: "bg-warning text-white" },
+        rejected:    { label: "Rejected",    classes: "bg-error text-white" },
+        unsubmitted: { label: "Not in feeds", classes: "bg-neutral-200 text-neutral-700" }
+    }.freeze
+
+    def moderation_state_badge(content)
+        style = MODERATION_BADGE_STYLES[content.moderation_state]
+        return nil unless style
+
+        content_tag(:span, style[:label],
+            class: "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium #{style[:classes]}")
+    end
+
     # Returns a +string+ summarizing the content's +start_time+ and +end_time+.
     #
     #   schedule_summary(content) # => "Always active"

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -45,6 +45,19 @@ class Content < ApplicationRecord
       true
     end
 
+    # Summarizes the overall moderation state of this content across all its
+    # submissions. Highest-priority state wins so a single approved submission
+    # surfaces as :approved even when other submissions are pending/rejected.
+    # Reads from the loaded `submissions` association to play nicely with
+    # `includes(:submissions)` on list views.
+    def moderation_state
+      statuses = submissions.map { |s| s.moderation_status.to_s }
+      return :unsubmitted if statuses.empty?
+      return :approved if statuses.include?("approved")
+      return :pending  if statuses.include?("pending")
+      :rejected
+    end
+
     private
 
     # Fields that trigger re-moderation when changed

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -26,6 +26,9 @@ class Content < ApplicationRecord
     scope :expired, -> { where("end_time IS NOT NULL AND end_time < :now", { now: Time.current }) }
     scope :upcoming, -> { where("start_time IS NOT NULL AND start_time > :now", { now: Time.current }) }
     scope :approved, -> { where(id: Submission.where(moderation_status: :approved).select(:content_id)) }
+    scope :with_name_matching, ->(query) {
+      where("LOWER(name) LIKE ?", "%#{sanitize_sql_like(query.to_s.downcase)}%")
+    }
 
     # Scopes for RSS feed content filtering
     scope :unused, -> { expired.where(text: [ nil, "" ]).where("name LIKE ?", "%(unused)") }

--- a/app/policies/content_policy.rb
+++ b/app/policies/content_policy.rb
@@ -1,8 +1,14 @@
 class ContentPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
-    # All users (including anonymous) can see approved content
+    # All users (including anonymous) can see approved content. Signed-in
+    # users additionally see content they own so pending/rejected/unsubmitted
+    # uploads remain discoverable to their author.
     def resolve
-      scope.approved
+      if user
+        scope.approved.or(scope.where(user_id: user.id))
+      else
+        scope.approved
+      end
     end
   end
 

--- a/app/views/contents/_grid.html.erb
+++ b/app/views/contents/_grid.html.erb
@@ -8,10 +8,15 @@
           </div>
           
           <div class="space-y-2">
-            <h3 class="text-h4 text-neutral-900 group-hover:text-brand transition-colors">
-              <%= content.name.presence || "Untitled Content" %>
-            </h3>
-            
+            <div class="flex items-start justify-between gap-2">
+              <h3 class="text-h4 text-neutral-900 group-hover:text-brand transition-colors">
+                <%= content.name.presence || "Untitled Content" %>
+              </h3>
+              <% if (badge = moderation_state_badge(content)) %>
+                <%= badge %>
+              <% end %>
+            </div>
+
             <div class="flex items-center justify-between text-caption text-neutral-500">
               <span class="capitalize"><%= content.class.name.downcase %></span>
               <span><%= time_ago_in_words(content.updated_at) %> ago</span>

--- a/app/views/contents/_grid.html.erb
+++ b/app/views/contents/_grid.html.erb
@@ -12,9 +12,7 @@
               <h3 class="text-h4 text-neutral-900 group-hover:text-brand transition-colors">
                 <%= content.name.presence || "Untitled Content" %>
               </h3>
-              <% if (badge = moderation_state_badge(content)) %>
-                <%= badge %>
-              <% end %>
+              <%= moderation_state_badge(content) %>
             </div>
 
             <div class="flex items-center justify-between text-caption text-neutral-500">

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -8,6 +8,7 @@
           when 'active' then 'Active Content'
           when 'upcoming' then 'Upcoming Content'
           when 'expired' then 'Expired Content'
+          when 'mine' then 'My Content'
           else 'All Content'
           end %>
     </h1>
@@ -16,6 +17,7 @@
           when 'active' then 'Content currently being displayed'
           when 'upcoming' then 'Content scheduled for future display'
           when 'expired' then 'Content that is no longer active'
+          when 'mine' then 'Everything you have uploaded, including pending and rejected submissions'
           else 'Manage and organize your digital signage content'
           end %>
     </p>
@@ -64,6 +66,16 @@
       <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-error text-white rounded-full">
         <%= Content.approved.expired.count %>
       </span>
+    <% end %>
+
+    <% if user_signed_in? %>
+      <%= link_to contents_path(scope: 'mine'),
+          class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@scope == 'mine' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+        Mine
+        <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-brand-500 text-white rounded-full">
+          <%= current_user.contents.count %>
+        </span>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -46,7 +46,7 @@
         <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <h2 class="text-h3 text-neutral-900">Content</h2>
 
-          <% if policy(@feed).edit? %>
+          <% if policy(@feed).edit? || user_signed_in? %>
             <!-- Moderation Status Toggle -->
             <div class="flex space-x-1 bg-neutral-100 p-1 rounded-lg">
               <%= link_to feed_path(@feed, status: "approved"),
@@ -57,20 +57,32 @@
                 </span>
               <% end %>
 
-              <%= link_to feed_path(@feed, status: "pending"),
-                  class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@status == 'pending' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
-                Pending
-                <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-warning text-white rounded-full">
-                  <%= @feed.submissions.pending.count %>
-                </span>
+              <% if policy(@feed).edit? %>
+                <%= link_to feed_path(@feed, status: "pending"),
+                    class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@status == 'pending' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+                  Pending
+                  <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-warning text-white rounded-full">
+                    <%= @feed.submissions.pending.count %>
+                  </span>
+                <% end %>
+
+                <%= link_to feed_path(@feed, status: "rejected"),
+                    class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@status == 'rejected' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+                  Rejected
+                  <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-error text-white rounded-full">
+                    <%= @feed.submissions.rejected.count %>
+                  </span>
+                <% end %>
               <% end %>
 
-              <%= link_to feed_path(@feed, status: "rejected"),
-                  class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@status == 'rejected' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
-                Rejected
-                <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-error text-white rounded-full">
-                  <%= @feed.submissions.rejected.count %>
-                </span>
+              <% if user_signed_in? %>
+                <%= link_to feed_path(@feed, status: "mine"),
+                    class: "px-3 py-2 text-sm font-medium rounded-md transition-colors #{@status == 'mine' ? 'bg-white text-brand-500 shadow-sm' : 'text-neutral-700 hover:text-neutral-900'}" do %>
+                  Mine
+                  <span class="ml-1.5 px-1.5 py-0.5 text-xs bg-brand-500 text-white rounded-full">
+                    <%= @feed.submissions.joins(:content).where(content: { user_id: current_user.id }).count %>
+                  </span>
+                <% end %>
               <% end %>
             </div>
           <% end %>
@@ -123,7 +135,13 @@
           <%= render partial: "contents/grid", locals: {contents: scoped_content} %>
         <% end %>
       <% else %>
-        <% submissions = @feed.submissions.includes(content: :user).where(moderation_status: @status) %>
+        <% submissions = if @status == "mine"
+             @feed.submissions.includes(content: :user)
+                  .joins(:content).where(content: { user_id: current_user.id })
+                  .order(created_at: :desc)
+           else
+             @feed.submissions.includes(content: :user).where(moderation_status: @status)
+           end %>
         <% if submissions.any? %>
           <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
             <% submissions.each do |submission| %>
@@ -137,8 +155,16 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
               </svg>
             </div>
-            <h3 class="text-body font-medium text-neutral-900 mb-2">No <%= @status %> submissions</h3>
-            <p class="text-body text-neutral-700">There are no <%= @status %> submissions for this feed.</p>
+            <% if @status == "mine" %>
+              <h3 class="text-body font-medium text-neutral-900 mb-2">No submissions from you</h3>
+              <p class="text-body text-neutral-700 mb-6">You haven't submitted any content to this feed yet.</p>
+              <% if policy(Content).create? %>
+                <%= link_to "Add Content", new_content_path, class: "btn btn-primary" %>
+              <% end %>
+            <% else %>
+              <h3 class="text-body font-medium text-neutral-900 mb-2">No <%= @status %> submissions</h3>
+              <p class="text-body text-neutral-700">There are no <%= @status %> submissions for this feed.</p>
+            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -91,7 +91,7 @@
 
       <% if @status == "approved" %>
         <%# Scope toggle for approved content - visible to all users %>
-        <% approved_content = @feed.approved_content %>
+        <% approved_content = @feed.approved_content.includes(:submissions) %>
         <div class="flex items-center gap-4 mb-6 border-b border-neutral-200">
           <%= link_to feed_path(@feed, status: @status, scope: "active"),
               class: "pb-2 text-sm font-medium border-b-2 transition-colors #{@scope == 'active' ? 'border-brand-500 text-brand-500' : 'border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300'}" do %>
@@ -135,16 +135,9 @@
           <%= render partial: "contents/grid", locals: {contents: scoped_content} %>
         <% end %>
       <% else %>
-        <% submissions = if @status == "mine"
-             @feed.submissions.includes(content: :user)
-                  .joins(:content).where(content: { user_id: current_user.id })
-                  .order(created_at: :desc)
-           else
-             @feed.submissions.includes(content: :user).where(moderation_status: @status)
-           end %>
-        <% if submissions.any? %>
+        <% if @submissions.any? %>
           <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
-            <% submissions.each do |submission| %>
+            <% @submissions.each do |submission| %>
               <%= render partial: "submissions/card", locals: { submission: submission } %>
             <% end %>
           </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -29,9 +29,6 @@
         <%= sidebar_nav_link_to "Dashboard", "/", "home" %>
         <%= sidebar_nav_link_to "Add Content", new_content_path, "plus" %>
         <%= sidebar_nav_link_to "Browse Content", contents_path, "collection" %>
-        <% if user_signed_in? %>
-          <%= sidebar_nav_link_to "My Content", contents_path(scope: "mine"), "document-text" %>
-        <% end %>
         <% if policy(Submission).pending? %>
           <%= sidebar_nav_link_to_with_badge "Moderation", submissions_path, "clipboard-document-check", pending_moderation_count %>
         <% end %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -29,6 +29,9 @@
         <%= sidebar_nav_link_to "Dashboard", "/", "home" %>
         <%= sidebar_nav_link_to "Add Content", new_content_path, "plus" %>
         <%= sidebar_nav_link_to "Browse Content", contents_path, "collection" %>
+        <% if user_signed_in? %>
+          <%= sidebar_nav_link_to "My Content", contents_path(scope: "mine"), "document-text" %>
+        <% end %>
         <% if policy(Submission).pending? %>
           <%= sidebar_nav_link_to_with_badge "Moderation", submissions_path, "clipboard-document-check", pending_moderation_count %>
         <% end %>

--- a/app/views/submissions/_card.html.erb
+++ b/app/views/submissions/_card.html.erb
@@ -43,9 +43,16 @@
       </div>
     </div>
 
-    <% if submission.pending? %>
+    <% if submission.pending? && policy(submission).moderate? %>
       <div class="mt-4 pt-4 border-t border-neutral-200">
         <%= render "submissions/moderation_actions", submission: submission %>
+      </div>
+    <% elsif submission.pending? %>
+      <div class="mt-4 pt-4 border-t border-neutral-200">
+        <p class="text-sm text-neutral-600">
+          <span class="font-medium text-neutral-700">Status:</span>
+          Awaiting moderation by a feed manager.
+        </p>
       </div>
     <% elsif submission.rejected? && submission.moderation_reason.present? %>
       <div class="mt-4 pt-4 border-t border-neutral-200">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -90,7 +90,7 @@
 
     <% if @user.contents.any? %>
       <div class="p-6">
-        <%= render partial: "contents/grid", locals: {contents: @user.contents} %>
+        <%= render partial: "contents/grid", locals: {contents: @user.contents.includes(:submissions)} %>
       </div>
     <% else %>
       <div class="px-6 py-12 text-center">

--- a/test/controllers/contents_controller_test.rb
+++ b/test/controllers/contents_controller_test.rb
@@ -79,4 +79,79 @@ class ContentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href^='/videos/']", count: 0
     assert_select "a[href^='/rich_texts/']", count: 0
   end
+
+  # Mine scope tests
+  test "Mine tab is hidden for anonymous users" do
+    get contents_url
+    assert_response :success
+    assert_select "a[href*='scope=mine']", count: 0
+  end
+
+  test "Mine tab is shown for signed-in users" do
+    sign_in users(:admin)
+    get contents_url
+    assert_response :success
+    assert_select "a[href*='scope=mine']"
+  end
+
+  test "scope=mine surfaces pending content owned by current user" do
+    pending_content = RichText.create!(
+      name: "My Pending", text: "Test", duration: 10, user: users(:non_member),
+      config: { "render_as" => "plaintext" }
+    )
+    Submission.create!(content: pending_content, feed: feeds(:one)) # auto-pending for non-member
+
+    sign_in users(:non_member)
+    get contents_url, params: { scope: "mine" }
+    assert_response :success
+    assert_select "a[href='#{rich_text_path(pending_content)}']"
+  end
+
+  test "scope=mine surfaces unsubmitted content owned by current user" do
+    draft = RichText.create!(
+      name: "My Draft", text: "Test", duration: 10, user: users(:non_member),
+      config: { "render_as" => "plaintext" }
+    )
+
+    sign_in users(:non_member)
+    get contents_url, params: { scope: "mine" }
+    assert_response :success
+    assert_select "a[href='#{rich_text_path(draft)}']"
+  end
+
+  test "scope=mine does not include content owned by other users" do
+    other_content = RichText.create!(
+      name: "Someone Else's", text: "Test", duration: 10, user: users(:admin),
+      config: { "render_as" => "plaintext" }
+    )
+
+    sign_in users(:non_member)
+    get contents_url, params: { scope: "mine" }
+    assert_response :success
+    assert_select "a[href='#{rich_text_path(other_content)}']", count: 0
+  end
+
+  test "scope=mine falls back to active for anonymous users" do
+    get contents_url, params: { scope: "mine" }
+    # Title reflects the fallback scope
+    assert_response :success
+    assert_select "h1", text: "Active Content"
+  end
+
+  test "scope=mine ?q= matches owner's content by name" do
+    needle = RichText.create!(
+      name: "Findable Draft", text: "Body", duration: 10, user: users(:non_member),
+      config: { "render_as" => "plaintext" }
+    )
+    decoy = RichText.create!(
+      name: "Unrelated Draft", text: "Body", duration: 10, user: users(:non_member),
+      config: { "render_as" => "plaintext" }
+    )
+
+    sign_in users(:non_member)
+    get contents_url, params: { scope: "mine", q: "Findable" }
+    assert_response :success
+    assert_select "a[href='#{rich_text_path(needle)}']"
+    assert_select "a[href='#{rich_text_path(decoy)}']", count: 0
+  end
 end

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -129,6 +129,66 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href*='status=approved'][href*='scope=active']"
   end
 
+  # Mine status tests (any signed-in user can see their own submissions)
+  test "anonymous user does not see Mine tab" do
+    get feed_url(@feed)
+    assert_response :success
+    assert_select "a[href*='status=mine']", count: 0
+  end
+
+  test "signed-in user sees Mine tab even when they cannot moderate" do
+    sign_in users(:non_member)
+    get feed_url(@feed)
+    assert_response :success
+    assert_select "a[href*='status=mine']"
+    # Non-member should not see moderator-only tabs
+    assert_select "a[href*='status=pending']", count: 0
+    assert_select "a[href*='status=rejected']", count: 0
+  end
+
+  test "status=mine surfaces pending submissions belonging to current user" do
+    # users(:admin) owns plain_richtext, which has a pending submission to @feed.
+    sign_in users(:admin)
+    get feed_url(@feed, status: "mine")
+    assert_response :success
+    assert_select "a[href='#{rich_text_path(rich_texts(:plain_richtext))}']"
+    # And the rejected one (html_richtext also owned by admin).
+    assert_select "a[href='#{rich_text_path(rich_texts(:html_richtext))}']"
+  end
+
+  test "status=mine hides another user's submissions" do
+    sign_in users(:non_member) # owns nothing in fixtures
+    get feed_url(@feed, status: "mine")
+    assert_response :success
+    # Neither admin's pending nor rejected submission should appear.
+    assert_select "a[href='#{rich_text_path(rich_texts(:plain_richtext))}']", count: 0
+    assert_select "a[href='#{rich_text_path(rich_texts(:html_richtext))}']", count: 0
+  end
+
+  test "status=mine for anonymous user falls back to approved" do
+    get feed_url(@feed, status: "mine")
+    assert_response :success
+    # Should show approved content, not enter Mine view.
+    assert_select "a[href='#{graphic_path(graphics(:one))}']"
+  end
+
+  test "non-moderator does not see moderation actions on their pending submissions" do
+    # non_member is not in @feed's group, so they cannot moderate.
+    pending = RichText.create!(
+      name: "Outsider Submission", text: "Test", duration: 10, user: users(:non_member),
+      config: { "render_as" => "plaintext" }
+    )
+    Submission.create!(content: pending, feed: @feed)
+
+    sign_in users(:non_member)
+    get feed_url(@feed, status: "mine")
+    assert_response :success
+    assert_select "a[href='#{rich_text_path(pending)}']"
+    # The Approve form posts to moderate_submission_path — it should not appear
+    # for a non-moderator viewing their own submission via Mine.
+    assert_select "form[action*='/moderate']", count: 0
+  end
+
   test "should redirect STI feed to proper controller" do
     rss_feed = rss_feeds(:yahoo_rssfeed)
     get feed_url(rss_feed)

--- a/test/policies/content_policy_test.rb
+++ b/test/policies/content_policy_test.rb
@@ -9,12 +9,61 @@ class ContentPolicyTest < ActiveSupport::TestCase
     @content = rich_texts(:plain_richtext)  # Owned by admin user
   end
 
-  test "scope returns only approved content for everyone" do
+  test "scope returns only approved content for anonymous users" do
     resolved_scope = ContentPolicy::Scope.new(nil, Content.all).resolve
-    assert_equal Content.approved.to_a, resolved_scope.to_a
+    assert_equal Content.approved.to_a.to_set, resolved_scope.to_a.to_set
+  end
 
+  test "scope returns approved content for users who own none of it" do
+    # @other_user owns no content in fixtures, so the additional OR clause
+    # contributes nothing — they still see exactly the approved set.
+    assert_equal 0, Content.where(user_id: @other_user.id).count
     resolved_scope = ContentPolicy::Scope.new(@other_user, Content.all).resolve
-    assert_equal Content.approved.to_a, resolved_scope.to_a
+    assert_equal Content.approved.to_a.to_set, resolved_scope.to_a.to_set
+  end
+
+  test "scope includes pending content owned by the signed-in user" do
+    # non_member is not in feed_one_owners, so submissions stay pending.
+    pending_content = RichText.create!(
+      name: "My Pending Content", text: "Test", duration: 10, user: @non_member,
+      config: { "render_as" => "plaintext" }
+    )
+    submission = Submission.create!(content: pending_content, feed: feeds(:one))
+    assert submission.pending?, "Expected submission to be pending"
+
+    assert_not_includes ContentPolicy::Scope.new(nil, Content.all).resolve, pending_content
+    assert_includes ContentPolicy::Scope.new(@non_member, Content.all).resolve, pending_content
+  end
+
+  test "scope includes rejected content owned by the signed-in user" do
+    rejected_content = RichText.create!(
+      name: "My Rejected Content", text: "Test", duration: 10, user: @non_member,
+      config: { "render_as" => "plaintext" }
+    )
+    Submission.create!(content: rejected_content, feed: feeds(:one))
+      .moderate!(status: :rejected, moderator: @content_owner, reason: "Nope")
+
+    assert_not_includes ContentPolicy::Scope.new(nil, Content.all).resolve, rejected_content
+    assert_includes ContentPolicy::Scope.new(@non_member, Content.all).resolve, rejected_content
+  end
+
+  test "scope includes unsubmitted content owned by the signed-in user" do
+    draft = RichText.create!(
+      name: "My Draft", text: "Test", duration: 10, user: @non_member,
+      config: { "render_as" => "plaintext" }
+    )
+
+    assert_not_includes ContentPolicy::Scope.new(nil, Content.all).resolve, draft
+    assert_includes ContentPolicy::Scope.new(@non_member, Content.all).resolve, draft
+  end
+
+  test "scope does not include another user's unapproved content" do
+    pending_content = RichText.create!(
+      name: "Someone Else's Draft", text: "Test", duration: 10, user: @non_member,
+      config: { "render_as" => "plaintext" }
+    )
+
+    assert_not_includes ContentPolicy::Scope.new(@other_user, Content.all).resolve, pending_content
   end
 
   test "scope excludes content with only pending submissions" do

--- a/test/services/search_test.rb
+++ b/test/services/search_test.rb
@@ -70,8 +70,9 @@ class SearchTest < ActiveSupport::TestCase
   test "call respects policy_scope — unapproved Content not returned even when in corpus" do
     # Inject an unapproved Content into the corpus directly to test post-fetch
     # filtering (a real-world way this happens: someone tampers with the index,
-    # or moderation state changes after a query).
-    unapproved = RichText.create!(name: "TopSecret", text: "matchterm", user: @admin, duration: 5, config: { render_as: "plaintext" })
+    # or moderation state changes after a query). Owned by a different user so
+    # the viewer-as-owner branch of the policy scope doesn't surface it.
+    unapproved = RichText.create!(name: "TopSecret", text: "matchterm", user: users(:non_member), duration: 5, config: { render_as: "plaintext" })
     Search::Corpus.upsert(unapproved, unapproved.searchable_data)
 
     results = Search.call("matchterm", user: @admin)


### PR DESCRIPTION
## Summary
- `ContentPolicy::Scope` now ORs in `where(user_id: user.id)` so signed-in users see their pending/rejected/unsubmitted content alongside the public approved set.
- `/contents` gains a **Mine** tab (and matching **My Content** sidebar shortcut) showing every upload by the current user, with `Pending` / `Rejected` / `Not in feeds` badges in the grid.
- `/feeds/:id` gains a **Mine** tab, visible to any signed-in user, that lists their submissions across all moderation statuses. Non-moderator owners see "Awaiting moderation by a feed manager" instead of the approve/reject form.

Fixes #1798.

## Test plan
- [x] `bin/rails test` — 990 runs, 0 failures (6 new policy-scope tests, 7 new contents-controller tests, 6 new feeds-controller tests; existing search test adjusted to use a non-owner viewer)
- [x] `bundle exec rubocop` clean
- [x] `yarn run vitest run` — 122 pass
- [x] `yarn run eslint` clean
- [x] Manual smoke (Playwright): signed in, sidebar shows **My Content**; `/contents?scope=mine` lists owned items including an unsubmitted draft with a `Not in feeds` badge; `/feeds/1?status=mine` renders the Mine tab with the empty-state CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)