### PR TITLE
Fix footer: replace copyright text and fix broken links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,11 +70,11 @@
       <div class="px-4 py-6 lg:px-6">
         <div class="flex flex-col sm:flex-row justify-between items-center text-caption text-neutral-700">
           <div class="mb-2 sm:mb-0">
-            © <%= Date.current.year %> Concerto Digital Signage. All rights reserved.
+            Powered by <a href="https://concerto-signage.org/" class="hover:text-neutral-900">Concerto Digital Signage</a>
           </div>
           <div class="flex space-x-4">
-            <a href="#" class="hover:text-neutral-900">Support</a>
-            <a href="#" class="hover:text-neutral-900">Documentation</a>
+            <a href="https://github.com/concerto/concerto/discussions/categories/q-a" class="hover:text-neutral-900">Support</a>
+            <a href="https://www.concerto-signage.org/docs" class="hover:text-neutral-900">Documentation</a>
             <span class="text-neutral-500">v<%= APP_VERSION %></span>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,11 +70,11 @@
       <div class="px-4 py-6 lg:px-6">
         <div class="flex flex-col sm:flex-row justify-between items-center text-caption text-neutral-700">
           <div class="mb-2 sm:mb-0">
-            Powered by <a href="https://concerto-signage.org/" class="hover:text-neutral-900">Concerto Digital Signage</a>
+            Powered by <a href="https://concerto-signage.org/" class="hover:text-neutral-900" target="_blank" rel="noopener noreferrer">Concerto Digital Signage</a>
           </div>
           <div class="flex space-x-4">
-            <a href="https://github.com/concerto/concerto/discussions/categories/q-a" class="hover:text-neutral-900">Support</a>
-            <a href="https://www.concerto-signage.org/docs" class="hover:text-neutral-900">Documentation</a>
+            <a href="https://github.com/concerto/concerto/discussions/categories/q-a" class="hover:text-neutral-900" target="_blank" rel="noopener noreferrer">Support</a>
+            <a href="https://www.concerto-signage.org/docs" class="hover:text-neutral-900" target="_blank" rel="noopener noreferrer">Documentation</a>
             <span class="text-neutral-500">v<%= APP_VERSION %></span>
           </div>
         </div>


### PR DESCRIPTION
Fixes #1721.

Originally submitted by @locchung in #1732 — taking this over since the contributor has been unresponsive to review feedback.

Changes:
- Replace `© ... All rights reserved.` with `Powered by Concerto Digital Signage` linking to the project website
- Update the broken Support `#` link to GitHub Discussions Q&A
- Update the broken Documentation `#` link to the docs site

Closes #1732.