### PR TITLE
Attempt unmuted video autoplay, fall back to muted

### DIFF
--- a/app/frontend/components/ConcertoTiktokVideo.vue
+++ b/app/frontend/components/ConcertoTiktokVideo.vue
@@ -15,7 +15,9 @@ const videoId = computed(() => {
 });
 
 const videoUrl = computed(() => {
-  return `https://www.tiktok.com/player/v1/${videoId.value}?autoplay=1&muted=1&loop=0&controls=0`;
+  // No `muted` param: try unmuted autoplay. The TikTok player automatically
+  // falls back to muted playback when the browser disallows unmuted autoplay.
+  return `https://www.tiktok.com/player/v1/${videoId.value}?autoplay=1&loop=0&controls=0`;
 });
 
 const playerRef = ref(null);

--- a/app/frontend/components/ConcertoVimeoVideo.vue
+++ b/app/frontend/components/ConcertoVimeoVideo.vue
@@ -118,10 +118,17 @@ onMounted(async () => {
 
   // The iframe URL requests autoplay, but Vimeo (unlike YouTube) does not
   // automatically retry muted when the browser rejects unmuted autoplay.
-  // Catch the rejection and fall back to muted playback.
-  if (typeof player.play === 'function') {
-    Promise.resolve(player.play()).catch(() => {
-      player.setMuted(true).then(() => player.play()).catch(() => {});
+  // Catch the rejection and fall back to muted playback. Capture a local
+  // reference so we don't dereference `player` after the component unmounts
+  // (onBeforeUnmount nulls it).
+  if (player && typeof player.play === 'function') {
+    const currentPlayer = player;
+    currentPlayer.play().catch(() => {
+      if (!player) return;
+      currentPlayer.setMuted(true).then(() => {
+        if (!player) return;
+        currentPlayer.play().catch(() => {});
+      }).catch(() => {});
     });
   }
 })

--- a/app/frontend/components/ConcertoVimeoVideo.vue
+++ b/app/frontend/components/ConcertoVimeoVideo.vue
@@ -18,7 +18,11 @@ const videoId = computed(() => {
 });
 
 const videoUrl = computed(() => {
-  return `https://player.vimeo.com/video/${videoId.value}?autoplay=1&muted=1&loop=0&api=1&background=1`;
+  // `background=1` would force muted playback, so we drop it and replicate its
+  // useful side-effects (no controls) explicitly. `muted=1` is also dropped so
+  // we can attempt unmuted autoplay; if the browser blocks it, the fallback in
+  // `onMounted` re-mutes and replays.
+  return `https://player.vimeo.com/video/${videoId.value}?autoplay=1&loop=0&controls=0&autopause=0&api=1`;
 });
 
 const playerRef = ref(null);
@@ -111,6 +115,15 @@ onMounted(async () => {
       emit('next', {});
     }
   });
+
+  // The iframe URL requests autoplay, but Vimeo (unlike YouTube) does not
+  // automatically retry muted when the browser rejects unmuted autoplay.
+  // Catch the rejection and fall back to muted playback.
+  if (typeof player.play === 'function') {
+    Promise.resolve(player.play()).catch(() => {
+      player.setMuted(true).then(() => player.play()).catch(() => {});
+    });
+  }
 })
 
 onBeforeUnmount(() => {

--- a/app/frontend/components/ConcertoYoutubeVideo.vue
+++ b/app/frontend/components/ConcertoYoutubeVideo.vue
@@ -19,7 +19,10 @@ const emit = defineEmits(['takeOverTimer', 'next'])
 const { ping: watchdogPing, stop: watchdogStop } = useVideoWatchdog(emit);
 
 const videoUrl = computed(() => {
-  return `https://www.youtube-nocookie.com/embed/${props.content.video_id}?rel=0&iv_load_policy=3&autoplay=1&controls=0&playsinline=1&mute=1&enablejsapi=1`;
+  // No `mute` param: try unmuted autoplay. Browsers that disallow it (no user
+  // gesture, low Media Engagement Index, not an installed PWA) cause the
+  // YouTube player to silently fall back to muted playback.
+  return `https://www.youtube-nocookie.com/embed/${props.content.video_id}?rel=0&iv_load_policy=3&autoplay=1&controls=0&playsinline=1&enablejsapi=1`;
 })
 
 const playerRef = ref(null);
@@ -89,6 +92,20 @@ function stopTimeCheck() {
   timeCheckInterval = null;
 }
 
+function onPlayerReady() {
+  // Try unmuted playback. If the browser blocks it, YouTube auto-mutes and
+  // continues playing — leaving us with audible playback when permitted and
+  // silent fallback otherwise.
+  if (player && typeof player.unMute === 'function') {
+    try {
+      player.unMute();
+      player.setVolume(100);
+    } catch {
+      // Player not ready or in error state; fine to ignore.
+    }
+  }
+}
+
 function onPlayerStateChange(event) {
   switch (event.data) {
   case YT.PlayerState.PLAYING:
@@ -125,6 +142,7 @@ onMounted(async () => {
 
   player = new YT.Player(playerRef.value, {
     events: {
+      'onReady': onPlayerReady,
       'onStateChange': onPlayerStateChange
     }
   });

--- a/test/frontend/components/ConcertoTiktokVideo.test.js
+++ b/test/frontend/components/ConcertoTiktokVideo.test.js
@@ -11,7 +11,17 @@ describe('ConcertoTiktokVideo', () => {
     const wrapper = mount(ConcertoTiktokVideo, { props: { content: content } });
 
     const iframe = wrapper.find('iframe');
-    expect(iframe.attributes('src')).toBe('https://www.tiktok.com/player/v1/6718335390845095173?autoplay=1&muted=1&loop=0&controls=0');
+    expect(iframe.attributes('src')).toBe('https://www.tiktok.com/player/v1/6718335390845095173?autoplay=1&loop=0&controls=0');
+  })
+
+  it('does not force muted playback in the iframe URL', () => {
+    const content = {
+      video_id: '6718335390845095173'
+    };
+    const wrapper = mount(ConcertoTiktokVideo, { props: { content: content } });
+
+    const src = wrapper.find('iframe').attributes('src');
+    expect(src).not.toMatch(/[?&]muted=1\b/);
   })
 
   it('applies the backend-provided aspect_ratio', () => {

--- a/test/frontend/components/ConcertoVimeoVideo.test.js
+++ b/test/frontend/components/ConcertoVimeoVideo.test.js
@@ -18,7 +18,18 @@ describe('ConcertoVimeoVideo', () => {
     };
     const wrapper = mount(ConcertoVimeoVideo, { props: { content: content } });
 
-    expect(wrapper.html()).toContain('src="https://player.vimeo.com/video/123456789?autoplay=1&amp;muted=1&amp;loop=0&amp;api=1&amp;background=1"');
+    expect(wrapper.html()).toContain('src="https://player.vimeo.com/video/123456789?autoplay=1&amp;loop=0&amp;controls=0&amp;autopause=0&amp;api=1"');
+  });
+
+  it('does not force muted or background mode in the iframe URL', () => {
+    const content = {
+      video_id: '123456789',
+    };
+    const wrapper = mount(ConcertoVimeoVideo, { props: { content: content } });
+
+    const src = wrapper.find('iframe').attributes('src');
+    expect(src).not.toMatch(/[?&]muted=1\b/);
+    expect(src).not.toMatch(/[?&]background=1\b/);
   });
 
   it('applies a backend-provided aspect_ratio', () => {
@@ -64,6 +75,49 @@ describe('ConcertoVimeoVideo dynamic aspect ratio', () => {
     await Promise.resolve();
     expect(mockPlayer.getVideoWidth).not.toHaveBeenCalled();
     expect(wrapper.find('iframe').attributes('style')).toContain('aspect-ratio: 16/9');
+  });
+});
+
+describe('ConcertoVimeoVideo unmuted autoplay fallback', () => {
+  let mockPlayer;
+
+  beforeEach(() => {
+    mockPlayer = {
+      on: vi.fn(),
+      play: vi.fn(),
+      setMuted: vi.fn().mockResolvedValue(undefined),
+    };
+    global.Vimeo.Player.mockImplementation(function() {
+      return mockPlayer;
+    });
+  });
+
+  it('does not call setMuted when unmuted autoplay succeeds', async () => {
+    mockPlayer.play.mockResolvedValue(undefined);
+    mount(ConcertoVimeoVideo, { props: { content: { video_id: '123456789' } } });
+
+    // Allow the play() promise to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockPlayer.setMuted).not.toHaveBeenCalled();
+  });
+
+  it('mutes and retries when the browser blocks unmuted autoplay', async () => {
+    let playCall = 0;
+    mockPlayer.play.mockImplementation(() => {
+      playCall += 1;
+      return playCall === 1
+        ? Promise.reject(new Error('NotAllowedError'))
+        : Promise.resolve();
+    });
+
+    mount(ConcertoVimeoVideo, { props: { content: { video_id: '123456789' } } });
+
+    await vi.waitFor(() => {
+      expect(mockPlayer.setMuted).toHaveBeenCalledWith(true);
+      expect(mockPlayer.play).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/test/frontend/components/ConcertoYoutubeVideo.test.js
+++ b/test/frontend/components/ConcertoYoutubeVideo.test.js
@@ -17,6 +17,16 @@ describe('ConcertoYoutubeVideo', () => {
     expect(wrapper.html()).toContain('src="https://www.youtube-nocookie.com/embed/z7HyF46-Zd0?rel=0&amp;iv_load_policy=3&amp;autoplay=1');
   })
 
+  it('does not force muted playback in the iframe URL', () => {
+    const content = {
+      video_id: 'z7HyF46-Zd0'
+    };
+    const wrapper = mount(ConcertoYoutubeVideo, { props: { content: content } });
+
+    const src = wrapper.find('iframe').attributes('src');
+    expect(src).not.toMatch(/[?&]mute=1\b/);
+  })
+
   it('applies the backend-provided aspect ratio to the iframe', () => {
     const content = {
       video_id: 'z7HyF46-Zd0',
@@ -39,6 +49,25 @@ describe('ConcertoYoutubeVideo duration control', () => {
         ENDED: 0
       }
     };
+  });
+
+  it('attempts unmuted playback on player ready', async () => {
+    const content = {
+      video_id: 'z7HyF46-Zd0',
+      duration: null
+    };
+    const playerInstance = {
+      unMute: vi.fn(),
+      setVolume: vi.fn(),
+    };
+    global.YT.Player.mockImplementation(() => playerInstance);
+    mount(ConcertoYoutubeVideo, { props: { content: content } });
+
+    const onReady = global.YT.Player.mock.calls[0][1].events.onReady;
+    onReady();
+
+    expect(playerInstance.unMute).toHaveBeenCalled();
+    expect(playerInstance.setVolume).toHaveBeenCalledWith(100);
   });
 
   it('takes over timer control when video has no duration', async () => {

--- a/test/frontend/components/ConcertoYoutubeVideo.test.js
+++ b/test/frontend/components/ConcertoYoutubeVideo.test.js
@@ -60,7 +60,9 @@ describe('ConcertoYoutubeVideo duration control', () => {
       unMute: vi.fn(),
       setVolume: vi.fn(),
     };
-    global.YT.Player.mockImplementation(() => playerInstance);
+    // Use a regular function so `new YT.Player(...)` works (arrow functions
+    // cannot be invoked as constructors).
+    global.YT.Player.mockImplementation(function() { return playerInstance; });
     mount(ConcertoYoutubeVideo, { props: { content: content } });
 
     const onReady = global.YT.Player.mock.calls[0][1].events.onReady;


### PR DESCRIPTION
## Summary

Drop the hardcoded mute parameters from the YouTube, Vimeo, and TikTok iframe URLs so the player tries unmuted autoplay. When the browser disallows it (no user gesture, low Media Engagement Index, not an installed PWA), each provider's player falls back to muted playback so the screen keeps rotating without manual intervention.

- **YouTube** — drop `mute=1` from URL; explicitly call `unMute()` + `setVolume(100)` in `onReady`. The IFrame player auto-mutes-and-plays when unmuted autoplay is blocked, so no manual fallback is needed.
- **Vimeo** — drop `muted=1` and `background=1` from URL (the latter forces muted+looped regardless of the muted param). Add `controls=0` and `autopause=0` to keep the previous "no controls, doesn't pause when another video plays" behavior. Vimeo doesn't auto-fall-back, so we catch the rejected `play()` promise and retry with `setMuted(true)`.
- **TikTok** — drop `muted=1` from URL. The TikTok player auto-falls-back to muted playback when blocked.

No new settings, opt-in flag, or unlock overlay — purely best-effort behavior. On a freshly opened browser the video plays silently (current behavior); on an installed PWA or a screen with enough Media Engagement history, it plays with sound.

Closes #1811

## Test plan

- [x] Updated component tests (`yarn run vitest`):
  - YouTube: asserts `mute=1` is absent from URL; new test verifies `unMute()` + `setVolume(100)` are called on player ready.
  - Vimeo: asserts new URL params (`controls=0&autopause=0`); new tests verify `setMuted(true)` is *not* called when unmuted `play()` succeeds, and *is* called as a fallback when it rejects.
  - TikTok: asserts `muted=1` is absent from URL.
- [ ] Manual: open a screen with a YouTube/Vimeo/TikTok video that has audio in a fresh Chrome profile — expected: plays silently (browser blocked unmuted autoplay), no console errors, watchdog never fires.
- [ ] Manual: install the player as a PWA or set Chrome site setting "Sound: Allow" — expected: videos play with sound; videos without audio still advance correctly.
- [ ] Cross-browser smoke (Firefox, Safari) — same expectations as the muted-fallback case.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oop4ZDQPPu5Uk6JyQowiK)_