### PR TITLE
Bump addressable from 2.8.9 to 2.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     aes_key_wrap (1.1.0)
     ast (2.4.3)


### PR DESCRIPTION
## Summary

- Bumps `addressable` from 2.8.9 to 2.9.0 to resolve [CVE-2026-35611](https://github.com/advisories/GHSA-h27x-rffw-24p4)
- Fixes the `bundler-audit` CI failure that was blocking unrelated PRs (e.g. #1816)
- `addressable` is an indirect dependency via `capybara` and `webmock`; both allow `>= 2.9.0`, so only `Gemfile.lock` changes

## Test plan

- [x] `bin/ci` passes locally (990 Ruby tests, 61 system tests, 122 frontend tests, bundler-audit clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)