### PR TITLE
Fix alarming "re-processing" alert on fresh graphic uploads

### DIFF
--- a/app/controllers/graphics_controller.rb
+++ b/app/controllers/graphics_controller.rb
@@ -9,10 +9,7 @@ class GraphicsController < ApplicationController
   def show
     authorize @graphic
 
-    if @graphic.image.attached? && !@graphic.image.analyzed? && !@graphic.processing?
-      @graphic.image.analyze_later()
-      flash.now[:alert] = "This graphic is queued for re-processing."
-    end
+    @graphic.image.analyze_later if @graphic.analysis_stuck?
   end
 
   # GET /graphics/new

--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -1,4 +1,6 @@
 class Graphic < Content
+  ANALYSIS_STUCK_AFTER = 60.seconds
+
   has_one_attached :image do |attachable|
     attachable.variant :grid, resize_to_limit: [ nil, 400 ]
     attachable.variant :preview, resize_to_limit: [ 1000, 1000 ]
@@ -24,6 +26,11 @@ class Graphic < Content
 
   def processing?
     image.attached? && image.content_type == "application/pdf"
+  end
+
+  def analysis_stuck?
+    image.attached? && image.variable? && !image.analyzed? &&
+      image.created_at < ANALYSIS_STUCK_AFTER.ago
   end
 
   def searchable_data

--- a/app/views/graphics/_graphic.html.erb
+++ b/app/views/graphics/_graphic.html.erb
@@ -23,6 +23,17 @@
           </div>
         <% end %>
       <% elsif graphic.image.attached? && graphic.image.variable? %>
+        <% if graphic.analysis_stuck? %>
+          <div class="mb-4 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4">
+            <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
+            </svg>
+            <div>
+              <p class="text-sm font-semibold text-amber-800">Image analysis hasn&rsquo;t completed yet</p>
+              <p class="mt-1 text-sm text-amber-700">Try refreshing in a moment. If this persists, contact an administrator.</p>
+            </div>
+          </div>
+        <% end %>
         <div class="flex justify-center">
           <%= link_to graphic.image, class: "block" do %>
             <%= image_tag graphic.image.variant(:preview),

--- a/test/controllers/graphics_controller_test.rb
+++ b/test/controllers/graphics_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class GraphicsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     @graphic = graphics(:one)
     @user = users(:admin)
@@ -9,6 +11,43 @@ class GraphicsControllerTest < ActionDispatch::IntegrationTest
   test "should show graphic when not logged in" do
     get graphic_url(@graphic)
     assert_response :success
+  end
+
+  test "show does not flash an alert for a freshly uploaded graphic" do
+    graphic = Graphic.new(name: "Fresh", duration: 10, user: @user)
+    graphic.image.attach(io: file_fixture("one.jpg").open, filename: "one.jpg", content_type: "image/jpeg")
+    graphic.save!
+    graphic.image.blob.update!(metadata: graphic.image.blob.metadata.except("analyzed"))
+
+    get graphic_url(graphic)
+    assert_response :success
+    assert_nil flash[:alert]
+    assert_select ".bg-amber-50", false, "Should not show analysis warning for fresh upload"
+  end
+
+  test "show does not re-enqueue analysis for a freshly uploaded graphic" do
+    graphic = Graphic.new(name: "Fresh", duration: 10, user: @user)
+    graphic.image.attach(io: file_fixture("one.jpg").open, filename: "one.jpg", content_type: "image/jpeg")
+    graphic.save!
+    graphic.image.blob.update!(metadata: graphic.image.blob.metadata.except("analyzed"))
+
+    assert_no_enqueued_jobs(only: ActiveStorage::AnalyzeJob) do
+      get graphic_url(graphic)
+    end
+  end
+
+  test "show re-enqueues analysis and shows warning when analysis is stuck" do
+    graphic = Graphic.new(name: "Stuck", duration: 10, user: @user)
+    graphic.image.attach(io: file_fixture("one.jpg").open, filename: "one.jpg", content_type: "image/jpeg")
+    graphic.save!
+    graphic.image.blob.update!(metadata: graphic.image.blob.metadata.except("analyzed"))
+    graphic.image.attachment.update!(created_at: 2.minutes.ago)
+
+    assert_enqueued_with(job: ActiveStorage::AnalyzeJob) do
+      get graphic_url(graphic)
+    end
+    assert_response :success
+    assert_select ".bg-amber-50"
   end
 
   test "should redirect new when not logged in" do

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -91,4 +91,49 @@ class GraphicTest < ActiveSupport::TestCase
       graphic.save!
     end
   end
+
+  test "analysis_stuck? returns false when image is not attached" do
+    graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
+    assert_not graphic.analysis_stuck?
+  end
+
+  test "analysis_stuck? returns false when image is freshly attached" do
+    graphic = Graphic.new(name: "Image Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: file_fixture("one.jpg").open, filename: "one.jpg", content_type: "image/jpeg")
+    graphic.save!
+    graphic.image.blob.update!(metadata: graphic.image.blob.metadata.except("analyzed"))
+    graphic.image.reload
+
+    assert_not graphic.analysis_stuck?
+  end
+
+  test "analysis_stuck? returns true when image attached over threshold ago and not analyzed" do
+    graphic = Graphic.new(name: "Image Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: file_fixture("one.jpg").open, filename: "one.jpg", content_type: "image/jpeg")
+    graphic.save!
+    graphic.image.blob.update!(metadata: graphic.image.blob.metadata.except("analyzed"))
+    graphic.image.attachment.update!(created_at: 2.minutes.ago)
+    graphic.image.reload
+
+    assert graphic.analysis_stuck?
+  end
+
+  test "analysis_stuck? returns false once image is analyzed" do
+    graphic = Graphic.new(name: "Image Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: file_fixture("one.jpg").open, filename: "one.jpg", content_type: "image/jpeg")
+    graphic.save!
+    graphic.image.attachment.update!(created_at: 2.minutes.ago)
+    graphic.image.analyze
+
+    assert_not graphic.analysis_stuck?
+  end
+
+  test "analysis_stuck? returns false for PDFs awaiting conversion" do
+    graphic = Graphic.new(name: "PDF Test", duration: 10, user: users(:admin))
+    graphic.image.attach(io: file_fixture("flyer.pdf").open, filename: "flyer.pdf", content_type: "application/pdf")
+    graphic.save!
+    graphic.image.attachment.update!(created_at: 2.minutes.ago)
+
+    assert_not graphic.analysis_stuck?
+  end
 end


### PR DESCRIPTION
## Summary
- Graphics show page no longer displays a red "Error" flash saying *"This graphic is queued for re-processing."* immediately after every upload — that message fired on the happy path because ActiveStorage's analyze job typically hadn't run yet when the redirect landed.
- Introduces `Graphic#analysis_stuck?` (image attached, variable, unanalyzed, and attached >60s ago). The view shows an inline amber warning only when this predicate is true, and the controller re-enqueues `analyze_later` only in that case.
- PDFs are non-variable, so `analysis_stuck?` returns false for them — the existing "Converting PDF to image…" / conversion-error UI is unchanged.

Fixes #1832 (reported by @bigG114 in #1763).

## Test plan
- [x] `bin/rails test` — full suite, 1000 runs, 0 failures
- [x] `bundle exec rubocop` — clean on changed Ruby files
- [x] New model tests cover: no image, fresh upload, stuck (>60s + unanalyzed), already analyzed, PDF awaiting conversion
- [x] New controller tests cover: no flash + no extra enqueue on fresh upload, warning + re-enqueue when stuck
- [ ] Manual: upload a graphic and confirm the show page renders cleanly without a flash error

🤖 Generated with [Claude Code](https://claude.com/claude-code)