### PR TITLE
Allow system admins to manage System Administrators group memberships

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -15,9 +15,10 @@ class Membership < ApplicationRecord
   private
 
   def cannot_remove_from_system_group
-    # Prevent manual removal from the system group, but allow deletion when this
-    # record is being destroyed due to a dependent destroy (e.g., user/group destroy).
-    return unless group&.system_group?
+    # Prevent manual removal from the auto-managed "All Registered Users" group,
+    # but allow deletion when the record is being destroyed due to a dependent
+    # destroy (e.g., user/group destroy). System Administrators is managed manually.
+    return unless group&.name == Group::REGISTERED_USERS_GROUP_NAME
     return if destroyed_by_association.present?
 
     errors.add(:base, 'Cannot remove users from the "All Registered Users" group')

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -66,7 +66,7 @@
               <th class="px-6 py-3 text-left text-label text-neutral-700">User</th>
               <th class="px-6 py-3 text-left text-label text-neutral-700">Role</th>
               <th class="px-6 py-3 text-left text-label text-neutral-700">Joined</th>
-              <% unless @group.system_group? %>
+              <% if policy(@group.memberships.build).create? %>
                 <th class="px-6 py-3 text-right text-label text-neutral-700">Actions</th>
               <% end %>
             </tr>
@@ -88,7 +88,7 @@
                   </div>
                 </td>
                 <td class="px-6 py-4">
-                  <% if @group.system_group? || !policy(membership).update? %>
+                  <% unless policy(membership).update? %>
                     <%= membership_role_badge(membership) %>
                   <% else %>
                     <%= form_with model: [@group, membership], method: :patch, local: true, class: "inline-block" do |form| %>
@@ -102,7 +102,7 @@
                 <td class="px-6 py-4 text-body text-neutral-500">
                   <%= membership.created_at.strftime("%B %d, %Y") %>
                 </td>
-                <% unless @group.system_group? %>
+                <% if policy(@group.memberships.build).create? %>
                   <td class="px-6 py-4 text-right">
                     <% if policy(membership).destroy? %>
                       <%= button_to group_membership_path(@group, membership),
@@ -134,7 +134,7 @@
 </div>
 
 <!-- Add Member Section -->
-<% unless @group.system_group? || @available_users.empty? %>
+<% unless @available_users.empty? %>
   <% if policy(@group.memberships.build).create? %>
     <div class="card mb-8">
       <div class="card-body p-6">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -58,6 +58,8 @@
       <h3 class="text-h3 text-neutral-900">Group Members</h3>
     </div>
     
+    <% can_manage_memberships = policy(@group.memberships.build).create? %>
+    <% show_actions_column = !@group.system_group? || can_manage_memberships %>
     <% if @members.any? %>
       <div class="overflow-x-auto">
         <table class="min-w-full">
@@ -66,7 +68,7 @@
               <th class="px-6 py-3 text-left text-label text-neutral-700">User</th>
               <th class="px-6 py-3 text-left text-label text-neutral-700">Role</th>
               <th class="px-6 py-3 text-left text-label text-neutral-700">Joined</th>
-              <% if policy(@group.memberships.build).create? %>
+              <% if show_actions_column %>
                 <th class="px-6 py-3 text-right text-label text-neutral-700">Actions</th>
               <% end %>
             </tr>
@@ -102,7 +104,7 @@
                 <td class="px-6 py-4 text-body text-neutral-500">
                   <%= membership.created_at.strftime("%B %d, %Y") %>
                 </td>
-                <% if policy(@group.memberships.build).create? %>
+                <% if show_actions_column %>
                   <td class="px-6 py-4 text-right">
                     <% if policy(membership).destroy? %>
                       <%= button_to group_membership_path(@group, membership),
@@ -135,7 +137,7 @@
 
 <!-- Add Member Section -->
 <% unless @available_users.empty? %>
-  <% if policy(@group.memberships.build).create? %>
+  <% if can_manage_memberships %>
     <div class="card mb-8">
       <div class="card-body p-6">
         <h3 class="text-h3 text-neutral-900 mb-4">Add New Member</h3>

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -140,6 +140,39 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", @group.name
   end
 
+  test "regular member sees remove button for own membership in a regular group" do
+    sign_in @regular_user
+    get group_url(@group)
+    assert_response :success
+    assert_select "th", "Actions"
+    membership = memberships(:regular_content_creator)
+    assert_select "form[action='#{group_membership_path(@group, membership)}']"
+  end
+
+  test "regular member cannot remove other members from a regular group" do
+    sign_in @regular_user
+    get group_url(@group)
+    assert_response :success
+    admin_membership = memberships(:admin_content_creator)
+    assert_select "form[action='#{group_membership_path(@group, admin_membership)}']", count: 0
+  end
+
+  test "regular member does not see actions column on all users system group" do
+    sign_in @regular_user
+    get group_url(@system_group)
+    assert_response :success
+    assert_select "th", { text: "Actions", count: 0 }
+    assert_select "button", { text: "Remove", count: 0 }
+  end
+
+  test "system admin sees actions column on system administrators group" do
+    sign_in @system_admin
+    sys_admins_group = groups(:system_administrators)
+    get group_url(sys_admins_group)
+    assert_response :success
+    assert_select "th", "Actions"
+  end
+
   test "should get edit" do
     sign_in @admin_user
     get edit_group_url(@group)

--- a/test/controllers/memberships_controller_test.rb
+++ b/test/controllers/memberships_controller_test.rb
@@ -208,6 +208,35 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to group_url(@system_group)
   end
 
+  test "system admin can add members to system group" do
+    sign_in @system_admin
+    new_user = User.create!(
+      email: "newsysuser@test.com",
+      first_name: "New",
+      last_name: "SysUser",
+      password: "password123"
+    )
+    system_admins_group = groups(:system_administrators)
+
+    assert_difference("Membership.count") do
+      post group_memberships_url(system_admins_group), params: {
+        membership: { user_id: new_user.id, role: "admin" }
+      }
+    end
+    assert_redirected_to group_url(system_admins_group)
+  end
+
+  test "system admin can remove members from system administrators group" do
+    sign_in @system_admin
+    sys_admins_group = groups(:system_administrators)
+    sys_admin_membership = memberships(:system_admin_in_system_administrators)
+
+    assert_difference("Membership.count", -1) do
+      delete group_membership_url(sys_admins_group, sys_admin_membership)
+    end
+    assert_redirected_to group_url(sys_admins_group)
+  end
+
   test "should handle invalid user when creating membership" do
     sign_in @admin_user
     assert_no_difference("Membership.count") do


### PR DESCRIPTION
## Summary

- **View**: Replaced four hardcoded `system_group?` guards in `groups/show.html.erb` with proper policy checks (`policy(...).create?` / `policy(membership).update?`). The policies were already correct — system admins already had access via `MembershipPolicy` calling `super` → `system_admin_only` — but the view never consulted them for system groups.
- **Model**: Narrowed the `cannot_remove_from_system_group` before_destroy callback to only protect `"All Registered Users"` (which is auto-managed via `after_create :add_to_all_users_group`). The "System Administrators" group should be manually manageable by system admins. The error message already said "All Registered Users" but the code was checking `system_group?`, which covers both.
- **Tests**: Added two controller tests covering system admin add/remove on the System Administrators group.

Closes #1847

## Test plan

- [ ] Sign in as a system admin and navigate to the System Administrators group — confirm Add Member form and Remove buttons are visible
- [ ] Add a user to the System Administrators group as a system admin — confirm it works
- [ ] Remove a user from the System Administrators group as a system admin — confirm it works
- [ ] Sign in as a non-system-admin and navigate to a system group — confirm management UI is still hidden
- [ ] Confirm removing from "All Registered Users" is still blocked for all users
- [ ] `bin/rails test test/controllers/memberships_controller_test.rb test/policies/membership_policy_test.rb test/models/membership_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)