### PR TITLE
Prevent the last System Administrator from being removed

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,7 +48,7 @@ module Admin
     def destroy
       authorize @user, :admin_manage?
 
-      if last_system_admin?(@user)
+      if @user.last_system_admin?
         redirect_to user_url(@user), alert: "Cannot delete the last system administrator."
         return
       end
@@ -69,11 +69,6 @@ module Admin
 
     def password_provided?
       params.dig(:user, :password).present?
-    end
-
-    def last_system_admin?(user)
-      return false unless user.system_admin?
-      Group.system_admins_group&.users&.count <= 1
     end
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -7,6 +7,7 @@ class Membership < ApplicationRecord
 
   # Prevent removal from system groups
   before_destroy :cannot_remove_from_system_group
+  before_destroy :cannot_remove_last_system_admin
 
   # Define the enum for roles
   # :member will be stored as 0 in the DB, :admin as 1
@@ -22,6 +23,14 @@ class Membership < ApplicationRecord
     return if destroyed_by_association.present?
 
     errors.add(:base, 'Cannot remove users from the "All Registered Users" group')
+    throw(:abort)
+  end
+
+  def cannot_remove_last_system_admin
+    return unless group&.system_admin_group?
+    return if Membership.where(group_id: group_id).where.not(id: id).exists?
+
+    errors.add(:base, "Cannot remove the last user from the System Administrators group")
     throw(:abort)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,11 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
 
+  # Registered before the has_many :memberships association so it runs
+  # before the dependent: :destroy cascade — otherwise the membership-level
+  # guard fires first and the user is left with a less helpful error.
+  before_destroy :cannot_destroy_last_system_admin
+
   has_many :contents, dependent: :destroy
   has_many :memberships, dependent: :destroy
   has_many :groups, through: :memberships
@@ -68,7 +73,22 @@ class User < ApplicationRecord
     groups.joins(:screens).exists?
   end
 
+  # True when this user is the only remaining member of the
+  # System Administrators group. Used to block destroy paths that
+  # would otherwise leave the install with no administrator.
+  def last_system_admin?
+    return false unless system_admin?
+    Group.system_admins_group.users.where.not(id: id).none?
+  end
+
   private
+
+  def cannot_destroy_last_system_admin
+    return unless last_system_admin?
+
+    errors.add(:base, "Cannot delete the last user in the System Administrators group")
+    throw(:abort)
+  end
 
   def add_to_all_users_group
     all_users_group = Group.find_or_create_by!(name: Group::REGISTERED_USERS_GROUP_NAME)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -36,6 +36,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def destroy?
+    return false if record&.last_system_admin?
     super || can_edit_user?
   end
 

--- a/test/controllers/memberships_controller_test.rb
+++ b/test/controllers/memberships_controller_test.rb
@@ -208,6 +208,20 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to group_url(@system_group)
   end
 
+  test "last system admin cannot leave the System Administrators group" do
+    sign_in @system_admin
+    system_admins_group = groups(:system_administrators)
+    membership = memberships(:system_admin_in_system_administrators)
+    assert_equal 1, system_admins_group.users.count
+
+    assert_no_difference("Membership.count") do
+      delete group_membership_url(system_admins_group, membership)
+    end
+
+    assert_redirected_to group_url(system_admins_group)
+    assert_match(/Cannot remove the last user/, flash[:alert])
+  end
+
   test "system admin can add members to system group" do
     sign_in @system_admin
     new_user = User.create!(
@@ -229,10 +243,10 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
   test "system admin can remove members from system administrators group" do
     sign_in @system_admin
     sys_admins_group = groups(:system_administrators)
-    sys_admin_membership = memberships(:system_admin_in_system_administrators)
+    extra_membership = Membership.create!(user: @admin_user, group: sys_admins_group, role: :admin)
 
     assert_difference("Membership.count", -1) do
-      delete group_membership_url(sys_admins_group, sys_admin_membership)
+      delete group_membership_url(sys_admins_group, extra_membership)
     end
     assert_redirected_to group_url(sys_admins_group)
   end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -67,4 +67,21 @@ class MembershipTest < ActiveSupport::TestCase
     regular_membership = memberships(:admin_content_creator)
     assert regular_membership.destroy
   end
+
+  test "should prevent removing the last user from the System Administrators group" do
+    last_admin_membership = memberships(:system_admin_in_system_administrators)
+    assert_equal 1, Group.system_admins_group.users.count
+
+    assert_not last_admin_membership.destroy
+    assert_includes last_admin_membership.errors[:base],
+                    "Cannot remove the last user from the System Administrators group"
+    assert Membership.exists?(last_admin_membership.id)
+  end
+
+  test "should allow removing a system admin when others remain" do
+    other_admin = users(:admin)
+    extra = Membership.create!(user: other_admin, group: groups(:system_administrators), role: :admin)
+
+    assert extra.destroy
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -104,7 +104,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "first human user is automatically added to system administrators group as admin" do
-    # Clear all non-system users to ensure we're creating the first one
+    # Clear all non-system users to ensure we're creating the first one.
+    # Memberships must be cleared first so the "last system admin" guard
+    # does not block destroying the fixture admin.
+    Membership.delete_all
     User.where(is_system_user: [ nil, false ]).destroy_all
 
     first_user = User.create!(
@@ -125,6 +128,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "second human user is not automatically added to system administrators group" do
     # Clear all non-system users and create first user
+    Membership.delete_all
     User.where(is_system_user: [ nil, false ]).destroy_all
 
     User.create!(
@@ -147,6 +151,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "system user is not added to system administrators group even if first" do
     # Clear all users to ensure we're creating the very first one
+    Membership.delete_all
     User.destroy_all
 
     system_user = User.create!(
@@ -160,6 +165,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "first human user after system users is added to system administrators group" do
     # Clear all users
+    Membership.delete_all
     User.destroy_all
 
     # Create a system user first
@@ -190,6 +196,40 @@ class UserTest < ActiveSupport::TestCase
     non_member = users(:non_member)
     # non_member is only in all_users group which has no screens
     assert_not non_member.screen_manager?, "User with no groups that own screens should not be a screen manager"
+  end
+
+  test "last_system_admin? returns true when user is the only system admin" do
+    assert_equal 1, Group.system_admins_group.users.count
+    assert users(:system_admin).last_system_admin?
+  end
+
+  test "last_system_admin? returns false when other system admins exist" do
+    other_admin = users(:admin)
+    Membership.create!(user: other_admin, group: groups(:system_administrators), role: :admin)
+
+    assert_not users(:system_admin).last_system_admin?
+    assert_not other_admin.last_system_admin?
+  end
+
+  test "last_system_admin? returns false for non system admins" do
+    assert_not users(:regular).last_system_admin?
+  end
+
+  test "should not destroy the last system administrator" do
+    last_admin = users(:system_admin)
+    assert_equal 1, Group.system_admins_group.users.count
+
+    assert_not last_admin.destroy
+    assert_includes last_admin.errors[:base],
+                    "Cannot delete the last user in the System Administrators group"
+    assert User.exists?(last_admin.id)
+  end
+
+  test "should destroy a system administrator when others remain" do
+    other_admin = users(:admin)
+    Membership.create!(user: other_admin, group: groups(:system_administrators), role: :admin)
+
+    assert users(:system_admin).destroy
   end
 
   test "screen_manager? returns false when user belongs to groups without screens" do

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -79,6 +79,17 @@ class UserPolicyTest < ActiveSupport::TestCase
     refute UserPolicy.new(@regular_user, @other_user).destroy?
   end
 
+  test "destroy? is denied when target is the last system admin" do
+    assert @system_admin_user.last_system_admin?
+    refute UserPolicy.new(@system_admin_user, @system_admin_user).destroy?
+  end
+
+  test "destroy? is denied for any actor against the last system admin" do
+    assert @system_admin_user.last_system_admin?
+    refute UserPolicy.new(@other_user, @system_admin_user).destroy?
+    refute UserPolicy.new(nil, @system_admin_user).destroy?
+  end
+
   # --- Admin Interface Methods ---
 
   test "admin_create? is permitted for system admins" do


### PR DESCRIPTION
## Summary
- Adds a `Membership` guard so the last member of the **System Administrators** group can no longer leave via the group membership UI (the previous guard only covered "All Registered Users").
- Adds a matching `User` `before_destroy` and `UserPolicy#destroy?` check so the same protection holds for user deletion paths, Rails console, etc.
- Centralizes the "only admin left" check on `User#last_system_admin?` and reuses it in `Admin::UsersController` instead of the controller's local copy.

Closes #1849.

## Test plan
- [x] `bin/rails test`
- [x] `bundle exec rubocop` on touched files
- [ ] Manual: as the only System Administrator, try to remove yourself from the group — expect a "Cannot remove the last user from the System Administrators group" alert.
- [ ] Manual: with a second admin added, removing either succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)