### PR TITLE
Retry content fetch when field returns empty to fix stale player

### DIFF
--- a/app/frontend/components/ConcertoField.vue
+++ b/app/frontend/components/ConcertoField.vue
@@ -92,6 +92,7 @@ async function loadContent(retryCount = 0) {
     } else {
       // No content yet — schedule a retry so we pick up newly added content
       // without requiring a manual page reload.
+      clearTimeout(loadContentRetryTimer);
       loadContentRetryTimer = setTimeout(() => loadContent(0), EMPTY_CONTENT_RETRY_DELAY_MS);
     }
   } catch (error) {

--- a/app/frontend/components/ConcertoField.vue
+++ b/app/frontend/components/ConcertoField.vue
@@ -22,6 +22,7 @@ const isDevelopment = import.meta.env.DEV;
 const INITIAL_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 10000;
 const LONG_RETRY_DELAY_MS = 60000;
+const EMPTY_CONTENT_RETRY_DELAY_MS = 30000;
 
 // Track config version to detect changes
 const { check: checkConfigVersion } = useConfigVersion('Field');
@@ -88,6 +89,10 @@ async function loadContent(retryCount = 0) {
 
     if (contentQueue.length > 0) {
       showNextContent();
+    } else {
+      // No content yet — schedule a retry so we pick up newly added content
+      // without requiring a manual page reload.
+      loadContentRetryTimer = setTimeout(() => loadContent(0), EMPTY_CONTENT_RETRY_DELAY_MS);
     }
   } catch (error) {
     console.error(`Failed to load content (attempt ${retryCount + 1}/${maxRetries + 1}):`, error);

--- a/test/frontend/components/ConcertoField.test.js
+++ b/test/frontend/components/ConcertoField.test.js
@@ -270,6 +270,40 @@ describe('ConcertoField', () => {
 
   });
 
+  describe('empty content retry', () => {
+    it('retries after 30 seconds when content is initially empty', async () => {
+      vi.useFakeTimers();
+
+      let callCount = 0;
+      server.use(
+        http.get(fieldContentUrl, () => {
+          callCount++;
+          if (callCount === 1) {
+            return HttpResponse.json([]);
+          }
+          return HttpResponse.json(fieldContent);
+        })
+      );
+
+      const wrapper = mount(ConcertoField, {
+        props: { apiUrl: fieldContentUrl },
+        global: { stubs: { transition: false } }
+      });
+
+      await flushPromises();
+
+      // First fetch returned empty — nothing displayed yet
+      expect(wrapper.findComponent(ConcertoGraphic).exists()).toBe(false);
+
+      // Advance past the 30s empty retry delay
+      vi.advanceTimersByTime(30000);
+      await flushPromises();
+
+      // Second fetch returned content — now displayed
+      expect(wrapper.findComponent(ConcertoGraphic).exists()).toBe(true);
+    });
+  });
+
   describe('preloading', () => {
     let preloadedImages = [];
 


### PR DESCRIPTION
## Summary

- When a field's API returned an empty array (no subscriptions, or empty feed), `loadContent()` would silently stop — no timer, no polling, nothing would ever trigger a refetch
- This left the player permanently blank until a manual page reload, which is the root cause of both scenarios in #1857
- Adds a 30-second retry in the empty-content path so newly added feeds/content are picked up automatically

## Test plan

- [ ] New vitest case: `empty content retry > retries after 30 seconds when content is initially empty` — confirms the component fetches again after the delay and displays content when it arrives
- [ ] All existing frontend tests continue to pass (`yarn run vitest`)
- [ ] ESLint clean (`yarn run eslint "{app,test}/frontend/**/*.{js,vue}"`)
- [ ] Manual: open a screen with an empty field, add content, verify it appears within ~30 seconds without a page reload

Closes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)