### PR TITLE
Reset session before each system test to fix flaky ContentsTest (#1834)

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,6 +9,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # System tests render full pages that often include video thumbnails
   # and the admin header which checks for updates via the GitHub API
   setup do
+    # Guarantee a clean, unauthenticated session at the start of every system
+    # test. Devise only resets Warden in teardown, and we otherwise rely on
+    # Capybara clearing the session cookie between tests -- which is unreliable
+    # with the remote Selenium driver used in CI. Resetting here neutralizes any
+    # authenticated session leaking in from a prior test, which otherwise causes
+    # anonymous tests to render content scoped to the leaked user. See #1834.
+    Warden.test_reset!
+    Capybara.reset_sessions!
+
     stub_oembed_apis
     stub_github_releases_api
   end

--- a/test/system/contents_test.rb
+++ b/test/system/contents_test.rb
@@ -5,7 +5,14 @@ class ContentsTest < ApplicationSystemTestCase
     visit contents_url
     assert_selector "h1", text: "Active Content"
 
-    assert_selector "#contents img", count: (Graphic.approved.active.count + Video.approved.active.count)
+    # This test depends on the anonymous policy scope (only approved content is
+    # shown to a signed-out user). The "New Content" button renders only for a
+    # signed-in user, so its absence confirms the session is truly anonymous and
+    # guards against an authenticated session leaking in from another test, which
+    # would otherwise inflate the image count -- see #1834.
+    assert_no_link "New Content"
+
+    assert_selector "#contents img", count: anonymous_image_count(Content.active)
     assert_selector "#contents div", text: rich_texts(:e2e_ticker_1).text
   end
 
@@ -13,7 +20,9 @@ class ContentsTest < ApplicationSystemTestCase
     visit contents_url(scope: "expired")
     assert_selector "h1", text: "Expired Content"
 
-    assert_selector "#contents img", count: (Graphic.approved.expired.count + Video.approved.expired.count)
+    assert_no_link "New Content"
+
+    assert_selector "#contents img", count: anonymous_image_count(Content.expired)
     assert_selector "#contents div", text: rich_texts(:plain_richtext).text
   end
 
@@ -27,5 +36,23 @@ class ContentsTest < ApplicationSystemTestCase
     has_link? "Add Graphic", href: new_graphic_path
     has_link? "Add Text / HTML", href: new_rich_text_path
     has_link? "Add Video", href: new_video_path
+  end
+
+  private
+
+  # Mirrors what the grid renders for an anonymous viewer: one <img> per piece
+  # of content visible to a signed-out user (approved only) that actually
+  # produces an image tag -- Graphics with a variable attachment and all Videos.
+  # Deriving the expected count the same way the page builds it keeps this test
+  # consistent regardless of who (if anyone) is signed in.
+  def anonymous_image_count(scope)
+    visible = ContentPolicy::Scope.new(nil, scope).resolve
+    visible.count do |content|
+      case content
+      when Graphic then content.image.attached? && content.image.variable?
+      when Video   then true
+      else              false
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failures tracked in #1834, where `ContentsTest`'s anonymous index tests failed with an **exact** image-count mismatch that passed on rerun:

- `test "visiting the index"`: `expected 4, found 7`
- `test "viewing expired content"`: `expected 1, found 6`

## Root cause

These tests render the **anonymous** content index, which goes through `ContentPolicy::Scope` — a signed-in user sees all of their *own* content, and every content fixture is owned by `admin`. The assertions, however, computed the expected count from a **session-independent** SQL query (`Graphic.approved.active.count + …`).

When an authenticated **admin** session leaked in from another test, the index additionally rendered admin's unapproved-but-active content, inflating the image count:

| Test | Anonymous (correct) | Admin-leaked (CI failure) |
|------|---------------------|---------------------------|
| active index | 4 | 7 (4 approved + 3 admin-owned active graphics w/ variable images) |
| expired index | 1 | 6 (1 graphic + all 5 expired videos) |

`4→7` and `1→6` match the CI logs exactly — confirming leaked auth state, not a timing race. Locally, Capybara reliably clears the session cookie between tests; with the **remote Selenium driver used in CI** it does not, which is why this only surfaced in CI and cleared on rerun.

## Changes

1. **Root cause** — `test/application_system_test_case.rb`: reset Warden and Capybara sessions in the shared `setup`, so no authenticated session can bleed into a later test regardless of teardown / cookie-clear races.
2. **Defensive + self-consistent** — `test/system/contents_test.rb`: the two anonymous cases now assert the signed-in-only "New Content" button is absent (directly catching a leaked session), and derive the expected image count through the anonymous policy scope using the same rules the grid uses to emit `<img>` tags (previously it counted approved graphics regardless of whether they have a variable attachment).

## Testing

- `bin/rails test:system` — 61 runs, 0 failures
- `bundle exec rubocop` on changed files — clean

Closes #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)