### PR TITLE
Grade content fit per position with fit_score (phase 1 of #1906)

### DIFF
--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -40,12 +40,21 @@ class Content < ApplicationRecord
         super(options)
     end
 
-    # should_render_in? determines if a piece of content is
-    # suitable to be rendered in a given position.
+    # fit_score rates how well this content suits a given position.
     #
-    # By default, it returns true.
+    # It returns a Float where 0.0 means "never render here" and larger
+    # values indicate a better fit. Subclasses override this with
+    # type-specific heuristics (see RichText and Graphic); the base class
+    # has no size preferences, so everything fits equally.
+    def fit_score(position)
+      1.0
+    end
+
+    # should_render_in? determines if a piece of content is suitable to be
+    # rendered in a given position. Content renders wherever it has a
+    # positive fit score.
     def should_render_in?(position)
-      true
+      fit_score(position).positive?
     end
 
     # Summarizes the overall moderation state of this content across all its

--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -38,15 +38,17 @@ class Graphic < Content
     { name: name, body: filename }
   end
 
-  # Determine if a graphic fits in a position or not.
+  # Aspect ratios within this multiple of the position's are a fit; anything
+  # more distorted is rejected. There is room to improve this. I just made up 2.0.
+  ASPECT_RATIO_TOLERANCE = 2.0
+
+  # Score how well a graphic fits a position based on aspect ratio.
   #
-  # If the height and width are known, the graphic will be
-  # rendered in positions with an aspect ratio twice a small
-  # or twice as large.
-  #
-  # There is room to improve this algorithm. I just made up 2.0.
-  def should_render_in?(position)
-    return false unless image.attached? && image.variable?
+  # When the dimensions are known, a graphic scores highest in positions
+  # whose aspect ratio matches its own, decaying to 0.0 at the edges of the
+  # tolerance window (ratios more than ASPECT_RATIO_TOLERANCE times off).
+  def fit_score(position)
+    return 0.0 unless image.attached? && image.variable?
 
     if !image.analyzed?
       logger.debug "graphic #{id} not analyzed, fallback rendering"
@@ -60,8 +62,13 @@ class Graphic < Content
 
     content_aspect_ratio = image.metadata[:width].fdiv(image.metadata[:height])
     position_aspect_ratio = position.aspect_ratio
+    ratio = content_aspect_ratio / position_aspect_ratio
 
-    (position_aspect_ratio / 2.0) <= content_aspect_ratio && content_aspect_ratio <= (position_aspect_ratio * 2.0)
+    return 0.0 unless (1.0 / ASPECT_RATIO_TOLERANCE) <= ratio && ratio <= ASPECT_RATIO_TOLERANCE
+
+    # Grade by aspect-ratio closeness: an exact match scores 1.0, decaying to
+    # 0.0 at the edges of the tolerance window.
+    1.0 - Math.log2(ratio).abs / Math.log2(ASPECT_RATIO_TOLERANCE)
   end
 
   private

--- a/app/models/graphic.rb
+++ b/app/models/graphic.rb
@@ -64,7 +64,8 @@ class Graphic < Content
     position_aspect_ratio = position.aspect_ratio
     ratio = content_aspect_ratio / position_aspect_ratio
 
-    return 0.0 unless (1.0 / ASPECT_RATIO_TOLERANCE) <= ratio && ratio <= ASPECT_RATIO_TOLERANCE
+    # Reject aspect ratios outside the tolerance window in either direction.
+    return 0.0 unless ratio.between?(1.0 / ASPECT_RATIO_TOLERANCE, ASPECT_RATIO_TOLERANCE)
 
     # Grade by aspect-ratio closeness: an exact match scores 1.0, decaying to
     # 0.0 at the edges of the tolerance window.

--- a/app/models/rich_text.rb
+++ b/app/models/rich_text.rb
@@ -20,29 +20,48 @@ class RichText < Content
         })
     end
 
-    # Determine if a piece of rich text fits in a position or not.
+    # A "large" position takes up more than this fraction of the screen area.
+    LARGE_AREA_THRESHOLD = 0.20
+    # Large positions need at least this much text or it scales up too big.
+    MIN_LARGE_POSITION_CHARS = 100
+    # Rough character "capacity" of a position per unit of screen area,
+    # calibrated so a position at LARGE_AREA_THRESHOLD holds
+    # MIN_LARGE_POSITION_CHARS characters. These values are arbitrary and may
+    # need tuning.
+    CHARS_PER_AREA = MIN_LARGE_POSITION_CHARS / LARGE_AREA_THRESHOLD
+    # How far text may run over a position's capacity before it's a poor fit.
+    OVER_CAPACITY_FACTOR = 2.0
+
+    # Score how well a piece of rich text fits a position based on its size.
     #
-    # If the position is large and there's not a lot of text, it will
-    # need to be scaled up and look unreasonable large. We should not
-    # render it.
-    def should_render_in?(position)
+    # Text that is too short for a large position scales up to an
+    # unreasonably large font; text that overflows a tiny position is
+    # unreadable. Both are rejected (score 0.0). In between, the score peaks
+    # when the text length is close to the position's capacity so the
+    # best-fitting position ranks highest.
+    def fit_score(position)
       # Don't render if there's no text.
-      return false if text.blank?
+      return 0.0 if text.blank?
 
       # Strip HTML for a more accurate character count.
       plain_text = ActionController::Base.helpers.strip_tags(text)
-      return false if plain_text.blank?
+      return 0.0 if plain_text.blank?
 
-      # This is a heuristic to prevent rendering a small amount of text
-      # in a very large position, which would result in unreasonably
-      # large font sizes.
-      # A "large" position is one that takes up > 20% of the screen area.
-      # A "small" amount of text is < 100 characters.
-      # These values are arbitrary and may need tuning.
-      return false if position.area > 0.20 && plain_text.length < 100
+      length = plain_text.length
+      capacity = position.area * CHARS_PER_AREA
 
-      # By default, rich text can be rendered.
-      true
+      if position.area > LARGE_AREA_THRESHOLD
+        # Lower bound: keep short text out of large positions, where it would
+        # scale up to an unreasonably large font.
+        return 0.0 if length < MIN_LARGE_POSITION_CHARS
+      else
+        # Upper bound: keep walls of text out of small positions, where they
+        # would overflow or shrink to an unreadable size.
+        return 0.0 if length > capacity * OVER_CAPACITY_FACTOR
+      end
+
+      # Grade by how close the text length is to the position's capacity.
+      capacity / (capacity + (length - capacity).abs)
     end
 
     def searchable_data

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -22,6 +22,22 @@ class GraphicTest < ActiveSupport::TestCase
     assert_not graphics(:pdf_graphic).should_render_in?(positions(:two_graphic))
   end
 
+  test "fit_score is zero for a position outside the aspect-ratio window" do
+    assert_equal 0.0, @graphic.fit_score(positions(:two_ticker))
+  end
+
+  test "fit_score scores a closer aspect ratio higher" do
+    # The graphic's aspect ratio (~1.33) sits closer to the time position
+    # (~1.75) than to the taller main position (~0.74), so it should score
+    # higher there even though both are inside the tolerance window.
+    time = @graphic.fit_score(positions(:two_time))
+    main = @graphic.fit_score(positions(:two_graphic))
+
+    assert time.positive?
+    assert main.positive?
+    assert time > main, "the closer-matched position should score higher"
+  end
+
   test "renders portrait images in similarly-shaped positions" do
     portrait = graphics(:portrait_graphic)
     assert portrait.should_render_in?(positions(:two_graphic))

--- a/test/models/rich_text_test.rb
+++ b/test/models/rich_text_test.rb
@@ -57,4 +57,29 @@ class RichTextTest < ActiveSupport::TestCase
     assert_not rich_text_short.should_render_in?(@large_position), "Should not render short text in large position"
     assert rich_text_long.should_render_in?(@large_position), "Should render long text in large position"
   end
+
+  test "fit_score is zero for blank text" do
+    assert_equal 0.0, RichText.new(text: "").fit_score(@large_position)
+    assert_equal 0.0, RichText.new(text: nil).fit_score(@small_position)
+  end
+
+  test "fit_score rejects a wall of text in a tiny position" do
+    # The ticker is a small position; a long blurb overflows it.
+    long = RichText.new(text: "a" * 153)
+    assert_equal 0.0, long.fit_score(@small_position), "153 chars should not fit the ticker"
+  end
+
+  test "fit_score keeps mid-length text in a mid-sized position" do
+    sidebar = positions(:two_sidebar)
+    assert RichText.new(text: "a" * 153).fit_score(sidebar).positive?,
+      "153 chars should fit the sidebar"
+  end
+
+  test "fit_score peaks when text length is near the position capacity" do
+    near_capacity = RichText.new(text: "a" * 38) # ~ticker capacity
+    sparse = RichText.new(text: "a" * 5)
+
+    assert near_capacity.fit_score(@small_position) > sparse.fit_score(@small_position),
+      "text sized to the position should outscore very sparse text"
+  end
 end


### PR DESCRIPTION
## What & why

Phase 1 of #1906 (content repeated in multiple positions). This PR reworks how we decide whether a piece of content suits a screen position, laying the groundwork for the follow-up that will dedupe content to its single best position.

The old `should_render_in?` was a boolean with weak heuristics:
- `RichText` only rejected *short* text in *large* positions. Once text was ≥100 chars there was no upper bound and no size preference, so a ~153-char blurb "fit" Main, Sidebar, and Ticker equally.
- `Graphic` was a pass/fail aspect-ratio window with no notion of "better."

## Approach

Replace the boolean with a graded **`fit_score(position) → Float`** (`0.0` = never render here; higher = better fit). `should_render_in?` becomes a thin wrapper (`fit_score(position).positive?`), so every existing call site — including `Frontend::ContentController` — is unchanged.

- **`RichText#fit_score`**: score text against a position's area-scaled character *capacity*.
  - *Large* positions (>20% area) keep the existing lower bound (reject text under 100 chars), no upper limit so long articles still render.
  - *Small* positions gain a **new upper bound** — reject text that overflows (>2× capacity). This stops a wall of text from rendering in a tiny ticker.
  - In band, the score peaks when text length ≈ capacity, so the best-fitting position ranks highest.
- **`Graphic#fit_score`**: same ½×–2× aspect-ratio window, now graded — an exact aspect match scores `1.0`, decaying to `0` at the window edges. Unattached/unanalyzed/PDF still score `0`/fall back, unchanged.

The scoring constants (`CHARS_PER_AREA`, `OVER_CAPACITY_FACTOR`, `ASPECT_RATIO_TOLERANCE`) are deliberately tunable and documented in comments.

## Follow-up (phase 2, separate PR)

`fetch_subscription_content` will gather each content's candidate positions (every position on the screen whose field carries it) and render it only where it's the `fit_score` argmax — deduping it to a single position. That's the part that actually fixes the "same content in 3 positions at once" symptom; this PR makes the score it needs.

## Testing

- New `fit_score` unit tests for the new bounds and ranking behavior.
- Existing `should_render_in?` tests unchanged and passing.
- Full suite green (`bin/rails test`: 1073 runs, 0 failures), rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)