### PR TITLE
Dedupe content to its best-fit field across a screen (phase 2 of #1906)

### DIFF
--- a/app/controllers/frontend/content_controller.rb
+++ b/app/controllers/frontend/content_controller.rb
@@ -36,16 +36,63 @@ class Frontend::ContentController < Frontend::ApplicationController
   def fetch_subscription_content
     subscriptions = @screen.subscriptions.where(field_id: @field.id)
 
-    # Build content items with subscription metadata and filter by position compatibility
-    content_items = subscriptions.flat_map do |subscription|
-      subscription.contents.active.filter_map do |content|
-        { content: content, subscription: subscription } if content.should_render_in?(@position)
+    items = subscriptions.flat_map do |subscription|
+      subscription.contents.active.map do |content|
+        { content: content, subscription: subscription }
       end
     end
+
+    # Dedupe across fields: when a feed is subscribed to several fields, keep
+    # each piece of content only in the field where it fits best so it isn't
+    # rendered in multiple positions at once. Content that fits nowhere on the
+    # screen is dropped.
+    best_field = best_field_by_content(items.map { |item| item[:content] })
+    content_items = items.select { |item| best_field[item[:content].id] == @field.id }
 
     # Apply ordering strategy (defaults to "random" if no config or blank strategy)
     strategy = @field_config&.ordering_strategy.presence || "random"
     orderer = ContentOrderers.for(strategy)
     orderer.call(content_items)
+  end
+
+  # Maps each content id to the field id on this screen where it fits best.
+  #
+  # A content's candidate fields are those whose subscribed feed carries it.
+  # Each field is scored via its position in the screen's template, and the
+  # highest-scoring field wins (ties broken by lowest field id). Because this
+  # only depends on the screen's subscriptions and template, every field's
+  # independent request computes the same winner, so content lands in exactly
+  # one field. Fields with no template position, or where the content has no
+  # positive fit, are not eligible.
+  def best_field_by_content(contents)
+    content_ids = contents.map(&:id).uniq
+    return {} if content_ids.empty?
+
+    position_by_field = @screen.template.positions.index_by(&:field_id)
+    contents_by_id = contents.index_by(&:id)
+
+    # content_id => [field_id, ...] for every field on this screen carrying it
+    field_ids_by_content = Submission.approved
+      .where(content_id: content_ids)
+      .joins(feed: :subscriptions)
+      .where(subscriptions: { screen_id: @screen.id })
+      .distinct
+      .pluck(:content_id, "subscriptions.field_id")
+      .group_by(&:first)
+
+    content_ids.index_with do |content_id|
+      content = contents_by_id[content_id]
+
+      (field_ids_by_content[content_id] || [])
+        .map(&:last)
+        .uniq
+        .filter_map do |field_id|
+          position = position_by_field[field_id]
+          score = position && content.fit_score(position)
+          [ field_id, score ] if score&.positive?
+        end
+        .max_by { |field_id, score| [ score, -field_id ] }
+        &.first
+    end
   end
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -50,13 +50,6 @@ class Content < ApplicationRecord
       1.0
     end
 
-    # should_render_in? determines if a piece of content is suitable to be
-    # rendered in a given position. Content renders wherever it has a
-    # positive fit score.
-    def should_render_in?(position)
-      fit_score(position).positive?
-    end
-
     # Summarizes the overall moderation state of this content across all its
     # submissions. Highest-priority state wins so a single approved submission
     # surfaces as :approved even when other submissions are pending/rejected.

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -50,15 +50,22 @@ class Video < Content
   end
 
   # Allow videos in positions whose aspect ratio is within 4x of the video's
-  # own, mirroring Graphic#should_render_in?. 4x keeps tickers and other
-  # extreme banner shapes out while still allowing cross-orientation placement
-  # (e.g. a 9:16 short in a 16:9 main), which is OK because the player
-  # letterboxes to fit. A tighter 2x-3x bound is more shape-aware but rejects
-  # useful cross-orientation cases.
-  def should_render_in?(position)
+  # own, mirroring Graphic#fit_score. 4x keeps tickers and other extreme
+  # banner shapes out while still allowing cross-orientation placement (e.g. a
+  # 9:16 short in a 16:9 main), which is OK because the player letterboxes to
+  # fit. A tighter 2x-3x bound is more shape-aware but rejects useful
+  # cross-orientation cases.
+  ASPECT_RATIO_TOLERANCE = 4.0
+
+  # Score how well a video fits a position by aspect ratio: an exact match
+  # scores 1.0, decaying to 0.0 at the edges of the tolerance window.
+  def fit_score(position)
     width, height = effective_aspect_ratio.split("/").map(&:to_f)
-    ratio = width / height
-    (position.aspect_ratio / 4.0) <= ratio && ratio <= (position.aspect_ratio * 4.0)
+    ratio = (width / height) / position.aspect_ratio
+
+    return 0.0 unless ratio.between?(1.0 / ASPECT_RATIO_TOLERANCE, ASPECT_RATIO_TOLERANCE)
+
+    1.0 - Math.log2(ratio).abs / Math.log2(ASPECT_RATIO_TOLERANCE)
   end
 
   def video_id

--- a/test/controllers/frontend/content_controller_test.rb
+++ b/test/controllers/frontend/content_controller_test.rb
@@ -297,6 +297,47 @@ class Frontend::ContentControllerTest < ActionDispatch::IntegrationTest
     assert_equal high_content.id, data.first["id"]
   end
 
+  test "renders content only in its best-fit field when a feed spans multiple fields" do
+    setup_multi_field_scenario
+
+    # ~150 chars fits the large Main position better than the smaller Sidebar.
+    main_content = create_richtext("a" * 150)
+    # ~120 chars fits the Sidebar's capacity more closely than Main.
+    sidebar_content = create_richtext("b" * 120)
+
+    main_ids = ids_for(field: fields(:main), position: positions(:two_graphic))
+    sidebar_ids = ids_for(field: fields(:sidebar), position: positions(:two_sidebar))
+
+    assert_includes main_ids, main_content.id
+    assert_not_includes main_ids, sidebar_content.id
+
+    assert_includes sidebar_ids, sidebar_content.id
+    assert_not_includes sidebar_ids, main_content.id
+
+    # Every piece of content renders in exactly one of the two fields.
+    assert_equal [ main_content.id, sidebar_content.id ].sort, (main_ids + sidebar_ids).sort
+  end
+
+  test "drops content that fits no subscribed field" do
+    # Subscribe the feed only to the two small fields (Sidebar and Ticker),
+    # neither of which can hold a wall of text.
+    setup_multi_field_scenario(fields: [ fields(:sidebar), fields(:ticker) ])
+
+    huge = create_richtext("c" * 1000)   # overflows both small fields
+    small = create_richtext("d" * 50)    # fits, best in the Ticker
+
+    sidebar_ids = ids_for(field: fields(:sidebar), position: positions(:two_sidebar))
+    ticker_ids = ids_for(field: fields(:ticker), position: positions(:two_ticker))
+
+    # The oversized content fits nowhere and is dropped from every field.
+    assert_not_includes sidebar_ids, huge.id
+    assert_not_includes ticker_ids, huge.id
+
+    # The small content still renders, in its best-fit field only.
+    assert_includes ticker_ids, small.id
+    assert_not_includes sidebar_ids, small.id
+  end
+
   test "should include config version header" do
     screen = screens(:one)
     get frontend_content_url(screen_id: screen.id, field_id: fields(:main).id, position_id: positions(:two_graphic).id)
@@ -309,6 +350,35 @@ class Frontend::ContentControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  # Screen 1 (Template Two) with one feed subscribed to several fields, so the
+  # same content is a candidate for multiple positions and must be deduped.
+  def setup_multi_field_scenario(fields: [ fields(:main), fields(:sidebar) ])
+    @screen = screens(:one)
+    Subscription.where(screen: @screen).destroy_all
+    FieldConfig.where(screen: @screen).destroy_all
+
+    @feed = Feed.create!(name: "Multi-field Feed", group: groups(:feed_one_owners))
+    fields.each { |field| Subscription.create!(screen: @screen, field: field, feed: @feed) }
+  end
+
+  def create_richtext(text)
+    content = RichText.create!(
+      name: "Content #{text.first}#{text.length}",
+      text: text,
+      user: users(:admin),
+      duration: 10,
+      config: { render_as: "plaintext" }
+    )
+    Submission.create!(content: content, feed: @feed)
+    content
+  end
+
+  def ids_for(field:, position:)
+    get frontend_content_url(screen_id: @screen.id, field_id: field.id, position_id: position.id)
+    assert_response :success
+    response.parsed_body.map { |c| c["id"] }
+  end
 
   def setup_subscription_scenario
     @screen = screens(:one)

--- a/test/models/graphic_test.rb
+++ b/test/models/graphic_test.rb
@@ -13,13 +13,13 @@ class GraphicTest < ActiveSupport::TestCase
   end
 
   test "should render images in appropriate fields" do
-    assert @graphic.should_render_in?(positions(:two_graphic))
+    assert @graphic.fit_score(positions(:two_graphic)).positive?
 
-    assert_not @graphic.should_render_in?(positions(:two_ticker))
+    assert_not @graphic.fit_score(positions(:two_ticker)).positive?
   end
 
   test "does not render when image is still a PDF" do
-    assert_not graphics(:pdf_graphic).should_render_in?(positions(:two_graphic))
+    assert_not graphics(:pdf_graphic).fit_score(positions(:two_graphic)).positive?
   end
 
   test "fit_score is zero for a position outside the aspect-ratio window" do
@@ -40,8 +40,8 @@ class GraphicTest < ActiveSupport::TestCase
 
   test "renders portrait images in similarly-shaped positions" do
     portrait = graphics(:portrait_graphic)
-    assert portrait.should_render_in?(positions(:two_graphic))
-    assert_not portrait.should_render_in?(positions(:two_ticker))
+    assert portrait.fit_score(positions(:two_graphic)).positive?
+    assert_not portrait.fit_score(positions(:two_ticker)).positive?
   end
 
   test "supported_content_types includes common web image formats" do
@@ -80,7 +80,7 @@ class GraphicTest < ActiveSupport::TestCase
   test "does not render unsupported content types in player" do
     graphic = Graphic.new(name: "Test", duration: 10, user: users(:admin))
     graphic.image.attach(io: StringIO.new("data"), filename: "test.exe", content_type: "application/octet-stream")
-    assert_not graphic.should_render_in?(positions(:two_graphic))
+    assert_not graphic.fit_score(positions(:two_graphic)).positive?
   end
 
   test "enqueues conversion job when PDF is attached on create" do

--- a/test/models/rich_text_test.rb
+++ b/test/models/rich_text_test.rb
@@ -22,40 +22,40 @@ class RichTextTest < ActiveSupport::TestCase
 
   test "should render in a small position with little text" do
     rich_text = RichText.new(text: "Some text")
-    assert rich_text.should_render_in?(@small_position)
+    assert rich_text.fit_score(@small_position).positive?
   end
 
   test "should render in a large position with enough text" do
     rich_text = RichText.new(text: "a" * 100)
-    assert rich_text.should_render_in?(@large_position)
+    assert rich_text.fit_score(@large_position).positive?
   end
 
   test "should not render in a large position with little text" do
     rich_text = RichText.new(text: "a" * 99)
-    assert_not rich_text.should_render_in?(@large_position)
+    assert_not rich_text.fit_score(@large_position).positive?
   end
 
   test "should not render if text is blank" do
     rich_text = RichText.new(text: "")
-    assert_not rich_text.should_render_in?(@large_position)
+    assert_not rich_text.fit_score(@large_position).positive?
   end
 
   test "should not render if text is nil" do
     rich_text = RichText.new(text: nil)
-    assert_not rich_text.should_render_in?(@large_position)
+    assert_not rich_text.fit_score(@large_position).positive?
   end
 
   test "should not render if text is only HTML tags and whitespace" do
     rich_text = RichText.new(text: " <strong> <em> </em> </strong> ")
-    assert_not rich_text.should_render_in?(@large_position)
+    assert_not rich_text.fit_score(@large_position).positive?
   end
 
   test "should correctly calculate text length after stripping HTML" do
     rich_text_short = RichText.new(text: "<strong>" + ("a" * 99) + "</strong>")
     rich_text_long = RichText.new(text: "<strong>" + ("a" * 100) + "</strong>")
 
-    assert_not rich_text_short.should_render_in?(@large_position), "Should not render short text in large position"
-    assert rich_text_long.should_render_in?(@large_position), "Should render long text in large position"
+    assert_not rich_text_short.fit_score(@large_position).positive?, "Should not render short text in large position"
+    assert rich_text_long.fit_score(@large_position).positive?, "Should render long text in large position"
   end
 
   test "fit_score is zero for blank text" do

--- a/test/models/video_test.rb
+++ b/test/models/video_test.rb
@@ -10,24 +10,24 @@ class VideoTest < ActiveSupport::TestCase
   end
 
   test "should render videos in appropriate fields" do
-    assert @youtube_video.should_render_in?(positions(:two_graphic)), positions(:two_graphic).aspect_ratio
-    assert_not @youtube_video.should_render_in?(positions(:two_ticker)), positions(:two_ticker).aspect_ratio
+    assert @youtube_video.fit_score(positions(:two_graphic)).positive?, positions(:two_graphic).aspect_ratio
+    assert_not @youtube_video.fit_score(positions(:two_ticker)).positive?, positions(:two_ticker).aspect_ratio
 
-    assert @vimeo_video.should_render_in?(positions(:two_graphic)), positions(:two_graphic).aspect_ratio
-    assert_not @vimeo_video.should_render_in?(positions(:two_ticker)), positions(:two_ticker).aspect_ratio
+    assert @vimeo_video.fit_score(positions(:two_graphic)).positive?, positions(:two_graphic).aspect_ratio
+    assert_not @vimeo_video.fit_score(positions(:two_ticker)).positive?, positions(:two_ticker).aspect_ratio
 
-    assert @tiktok_video.should_render_in?(positions(:two_graphic)), positions(:two_graphic).aspect_ratio
-    assert_not @tiktok_video.should_render_in?(positions(:two_ticker)), positions(:two_ticker).aspect_ratio
+    assert @tiktok_video.fit_score(positions(:two_graphic)).positive?, positions(:two_graphic).aspect_ratio
+    assert_not @tiktok_video.fit_score(positions(:two_ticker)).positive?, positions(:two_ticker).aspect_ratio
   end
 
   test "renders portrait videos in tall portrait positions" do
-    assert @youtube_short.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
-    assert @tiktok_video.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
+    assert @youtube_short.fit_score(positions(:two_sidebar)).positive?, positions(:two_sidebar).aspect_ratio
+    assert @tiktok_video.fit_score(positions(:two_sidebar)).positive?, positions(:two_sidebar).aspect_ratio
   end
 
   test "rejects landscape videos in tall portrait positions" do
-    assert_not @youtube_video.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
-    assert_not @vimeo_video.should_render_in?(positions(:two_sidebar)), positions(:two_sidebar).aspect_ratio
+    assert_not @youtube_video.fit_score(positions(:two_sidebar)).positive?, positions(:two_sidebar).aspect_ratio
+    assert_not @vimeo_video.fit_score(positions(:two_sidebar)).positive?, positions(:two_sidebar).aspect_ratio
   end
 
   test "extracts video id from youtube url" do


### PR DESCRIPTION
## What & why

Phase 2 (and the completing fix) for #1906 — content repeated in multiple positions on a screen. Builds on the `fit_score` groundwork from #1907.

Each field on a screen is rendered by an **independent, stateless request** to `Frontend::ContentController`. Nothing coordinated across fields, so when one feed was subscribed to (say) Main + Sidebar + Ticker, any content that fit all three rendered in all three at once — sometimes the same graphic or blurb in several positions simultaneously.

## Approach

Use the graded `fit_score` to assign each piece of content to the **single field where it fits best**, and render it only there:

- For the content in the current field, gather every field on the screen whose subscribed feed carries it (one `Submission … joins(feed: :subscriptions)` query).
- Score each candidate field via its position in the screen's template.
- The highest-scoring field wins; ties break by lowest field id.
- Keep the content in this field only if this field is the winner. Content that fits nowhere (positive score in no field) is dropped.

Because the winner is a **pure function of the screen's subscriptions + template**, every field's independent request computes the same answer — so content deterministically lands in exactly one field with no shared state or cross-request coordination.

Comparison is done by **field** (not position identity), which is robust to a request's `position_id` differing from the template's position for that field, and correct for the normal 1:1 field↔position case.

## Behavior change

`fetch_subscription_content` no longer gates on `should_render_in?(@position)` directly; the positive-fit requirement is now folded into the best-field selection (a field is only eligible if the content has a positive `fit_score` there). Net effect for a single-field subscription is unchanged; the new behavior only kicks in when a feed spans multiple fields.

## Testing

- New controller tests: content with a feed spanning Main + Sidebar dedupes to the better-fitting field (and each piece lands in exactly one); oversized content subscribed only to small fields is dropped everywhere while a well-sized piece still renders in its best field.
- All existing controller tests unchanged and passing.
- Full suite green (`bin/rails test`: 1075 runs, 0 failures), rubocop clean.

Closes #1906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)