### PR TITLE
Bump brace-expansion to fix ReDoS (CVE-2026-13149)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,20 +2394,20 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.3
-  resolution: "brace-expansion@npm:2.1.3"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/62bef43c5755b4978662d66d0844635cc171610644da7d0266db8c0180c21c6e8ff7b969a27d2f2ec7893b6efd9c33dc73383d84a467669832f2da1fd3771f99
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert #122: `brace-expansion` has an exponential-time (ReDoS) vulnerability in `expand()` — a short (~90 byte) attacker-controlled input with many consecutive non-expanding `{}` groups can hang a Node worker/process for minutes.
- CVE: [CVE-2026-13149](https://nvd.nist.gov/vuln/detail/CVE-2026-13149)
- GHSA: [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)
- `yarn.lock` had two resolved lines: `2.1.3` (already patched by an earlier Dependabot bump) and `5.0.4`, pulled in transitively via `minimatch@10.2.4` — still vulnerable (needs `>= 5.0.7`).
- `yarn up brace-expansion -R` bumps both to `2.1.4` and `5.0.9`. Dev-only, transitive dependency (via minimatch/glob tooling), no application code changes.

## Test plan

- [x] `yarn.lock` confirms both `brace-expansion` resolutions are now patched (`2.1.4`, `5.0.9`)
- [x] `yarn run vitest run` — 147 passed, 1 skipped (pre-existing, unrelated)